### PR TITLE
`const`-related changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ rust-version = "1.85.0"
 [dependencies]
 chrono = "0.4"
 num-traits = "0.2"
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-rand = "0.9.0"
+rand = "0.9"
 
 [features]
 # If no unsafe intrinsics active `forbid(unsafe)` will be used.

--- a/src/chad.rs
+++ b/src/chad.rs
@@ -43,12 +43,12 @@ use crate::matrix::{Matrix3f, Vector3f, XyY, Xyz};
 //         ],
 //     };
 //     let cone_source_rgb = chad.mul_vector(cone_source_xyz);
-// 
+//
 //     let cone_dest_xyz = Vector3f {
 //         v: [dest_white_point.x, dest_white_point.y, dest_white_point.z],
 //     };
 //     let cone_dest_rgb = chad.mul_vector(cone_dest_xyz);
-// 
+//
 //     let cone = Matrix3f {
 //         v: [
 //             [cone_dest_rgb.v[0] / cone_source_rgb.v[0], 0., 0.],
@@ -56,9 +56,9 @@ use crate::matrix::{Matrix3f, Vector3f, XyY, Xyz};
 //             [0., 0., cone_dest_rgb.v[2] / cone_source_rgb.v[2]],
 //         ],
 //     };
-// 
+//
 //     let chad_inv = chad.inverse()?;
-// 
+//
 //     let p0 = cone.mat_mul(chad);
 //     Some(chad_inv.mat_mul(p0))
 // }
@@ -150,11 +150,11 @@ pub(crate) const fn adapt_to_illuminant_const(
 //     if source_white_pt.y == 0.0 {
 //         return None;
 //     }
-// 
+//
 //     let xyz_wp = source_white_pt.to_xyz();
 //     adapt_to_illuminant_xyz(r, xyz_wp, illuminant_xyz)
 // }
-// 
+//
 // #[inline]
 // pub(crate) fn adapt_to_illuminant_xyz(
 //     r: Option<Matrix3f>,
@@ -164,7 +164,7 @@ pub(crate) const fn adapt_to_illuminant_const(
 //     if source_white_pt.y == 0.0 {
 //         return None;
 //     }
-// 
+//
 //     let bradford = adaption_matrix(source_white_pt, illuminant_xyz)?;
 //     Some(bradford.mat_mul(r?))
 // }

--- a/src/chad.rs
+++ b/src/chad.rs
@@ -26,7 +26,7 @@
  * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-use crate::Chromacity;
+use crate::Chromaticity;
 use crate::matrix::{Matrix3f, Vector3f, XyY, Xyz};
 
 #[inline]
@@ -77,7 +77,7 @@ fn adaption_matrix(source_illumination: Xyz, target_illumination: Xyz) -> Option
 }
 
 pub(crate) fn adapt_to_d50(r: Option<Matrix3f>, source_white_pt: XyY) -> Option<Matrix3f> {
-    adapt_to_illuminant(r, source_white_pt, Chromacity::D50.to_xyz())
+    adapt_to_illuminant(r, source_white_pt, Chromaticity::D50.to_xyz())
 }
 
 #[inline]

--- a/src/chad.rs
+++ b/src/chad.rs
@@ -29,39 +29,39 @@
 use crate::Chromaticity;
 use crate::matrix::{Matrix3f, Vector3f, XyY, Xyz};
 
-#[inline]
-fn compute_chromatic_adaption(
-    source_white_point: Xyz,
-    dest_white_point: Xyz,
-    chad: Matrix3f,
-) -> Option<Matrix3f> {
-    let cone_source_xyz = Vector3f {
-        v: [
-            source_white_point.x,
-            source_white_point.y,
-            source_white_point.z,
-        ],
-    };
-    let cone_source_rgb = chad.mul_vector(cone_source_xyz);
-
-    let cone_dest_xyz = Vector3f {
-        v: [dest_white_point.x, dest_white_point.y, dest_white_point.z],
-    };
-    let cone_dest_rgb = chad.mul_vector(cone_dest_xyz);
-
-    let cone = Matrix3f {
-        v: [
-            [cone_dest_rgb.v[0] / cone_source_rgb.v[0], 0., 0.],
-            [0., cone_dest_rgb.v[1] / cone_source_rgb.v[1], 0.],
-            [0., 0., cone_dest_rgb.v[2] / cone_source_rgb.v[2]],
-        ],
-    };
-
-    let chad_inv = chad.inverse()?;
-
-    let p0 = cone.mat_mul(chad);
-    Some(chad_inv.mat_mul(p0))
-}
+// #[inline]
+// fn compute_chromatic_adaption(
+//     source_white_point: Xyz,
+//     dest_white_point: Xyz,
+//     chad: Matrix3f,
+// ) -> Option<Matrix3f> {
+//     let cone_source_xyz = Vector3f {
+//         v: [
+//             source_white_point.x,
+//             source_white_point.y,
+//             source_white_point.z,
+//         ],
+//     };
+//     let cone_source_rgb = chad.mul_vector(cone_source_xyz);
+// 
+//     let cone_dest_xyz = Vector3f {
+//         v: [dest_white_point.x, dest_white_point.y, dest_white_point.z],
+//     };
+//     let cone_dest_rgb = chad.mul_vector(cone_dest_xyz);
+// 
+//     let cone = Matrix3f {
+//         v: [
+//             [cone_dest_rgb.v[0] / cone_source_rgb.v[0], 0., 0.],
+//             [0., cone_dest_rgb.v[1] / cone_source_rgb.v[1], 0.],
+//             [0., 0., cone_dest_rgb.v[2] / cone_source_rgb.v[2]],
+//         ],
+//     };
+// 
+//     let chad_inv = chad.inverse()?;
+// 
+//     let p0 = cone.mat_mul(chad);
+//     Some(chad_inv.mat_mul(p0))
+// }
 
 #[inline]
 const fn compute_chromatic_adaption_const(
@@ -97,18 +97,18 @@ const fn compute_chromatic_adaption_const(
     chad_inv.mat_mul_const(p0)
 }
 
-fn adaption_matrix(source_illumination: Xyz, target_illumination: Xyz) -> Option<Matrix3f> {
-    let lam_rigg = {
-        Matrix3f {
-            v: [
-                [0.8951, 0.2664, -0.1614],
-                [-0.7502, 1.7135, 0.0367],
-                [0.0389, -0.0685, 1.0296],
-            ],
-        }
-    };
-    compute_chromatic_adaption(source_illumination, target_illumination, lam_rigg)
-}
+// fn adaption_matrix(source_illumination: Xyz, target_illumination: Xyz) -> Option<Matrix3f> {
+//     let lam_rigg = {
+//         Matrix3f {
+//             v: [
+//                 [0.8951, 0.2664, -0.1614],
+//                 [-0.7502, 1.7135, 0.0367],
+//                 [0.0389, -0.0685, 1.0296],
+//             ],
+//         }
+//     };
+//     compute_chromatic_adaption(source_illumination, target_illumination, lam_rigg)
+// }
 
 const fn adaption_matrix_const(source_illumination: Xyz, target_illumination: Xyz) -> Matrix3f {
     let lam_rigg = {
@@ -123,9 +123,9 @@ const fn adaption_matrix_const(source_illumination: Xyz, target_illumination: Xy
     compute_chromatic_adaption_const(source_illumination, target_illumination, lam_rigg)
 }
 
-pub(crate) fn adapt_to_d50(r: Option<Matrix3f>, source_white_pt: XyY) -> Option<Matrix3f> {
-    adapt_to_illuminant(r, source_white_pt, Chromaticity::D50.to_xyz())
-}
+// pub(crate) fn adapt_to_d50(r: Option<Matrix3f>, source_white_pt: XyY) -> Option<Matrix3f> {
+//     adapt_to_illuminant(r, source_white_pt, Chromaticity::D50.to_xyz())
+// }
 
 pub(crate) const fn adapt_to_d50_const(r: Matrix3f, source_white_pt: XyY) -> Matrix3f {
     adapt_to_illuminant_const(r, source_white_pt, Chromaticity::D50.to_xyz())
@@ -141,30 +141,30 @@ pub(crate) const fn adapt_to_illuminant_const(
     bradford.mat_mul_const(r)
 }
 
-#[inline]
-pub(crate) fn adapt_to_illuminant(
-    r: Option<Matrix3f>,
-    source_white_pt: XyY,
-    illuminant_xyz: Xyz,
-) -> Option<Matrix3f> {
-    if source_white_pt.y == 0.0 {
-        return None;
-    }
-
-    let xyz_wp = source_white_pt.to_xyz();
-    adapt_to_illuminant_xyz(r, xyz_wp, illuminant_xyz)
-}
-
-#[inline]
-pub(crate) fn adapt_to_illuminant_xyz(
-    r: Option<Matrix3f>,
-    source_white_pt: Xyz,
-    illuminant_xyz: Xyz,
-) -> Option<Matrix3f> {
-    if source_white_pt.y == 0.0 {
-        return None;
-    }
-
-    let bradford = adaption_matrix(source_white_pt, illuminant_xyz)?;
-    Some(bradford.mat_mul(r?))
-}
+// #[inline]
+// pub(crate) fn adapt_to_illuminant(
+//     r: Option<Matrix3f>,
+//     source_white_pt: XyY,
+//     illuminant_xyz: Xyz,
+// ) -> Option<Matrix3f> {
+//     if source_white_pt.y == 0.0 {
+//         return None;
+//     }
+// 
+//     let xyz_wp = source_white_pt.to_xyz();
+//     adapt_to_illuminant_xyz(r, xyz_wp, illuminant_xyz)
+// }
+// 
+// #[inline]
+// pub(crate) fn adapt_to_illuminant_xyz(
+//     r: Option<Matrix3f>,
+//     source_white_pt: Xyz,
+//     illuminant_xyz: Xyz,
+// ) -> Option<Matrix3f> {
+//     if source_white_pt.y == 0.0 {
+//         return None;
+//     }
+// 
+//     let bradford = adaption_matrix(source_white_pt, illuminant_xyz)?;
+//     Some(bradford.mat_mul(r?))
+// }

--- a/src/cicp.rs
+++ b/src/cicp.rs
@@ -126,19 +126,40 @@ impl ColorPrimaries {
         },
     };
 
-    /// [Adobe RGB](https://en.wikipedia.org/wiki/DCI-P3) (1998).
+    /// [Adobe RGB](https://en.wikipedia.org/wiki/Adobe_RGB_color_space) (1998).
     pub const ADOBE_RGB: ColorPrimaries = ColorPrimaries {
         red: Chromaticity { x: 0.64, y: 0.33 },
         green: Chromaticity { x: 0.21, y: 0.71 },
         blue: Chromaticity { x: 0.15, y: 0.06 },
     };
 
-    /// [DCI-P3](https://en.wikipedia.org/wiki/DCI-P3).
+    /// [DCI P3](https://en.wikipedia.org/wiki/DCI-P3#DCI_P3).
+    ///
+    /// This is the same as [`DISPLAY_P3`](Self::DISPLAY_P3),
+    /// [`SMPTE_431`](Self::SMPTE_431) and [`SMPTE_432`](Self::SMPTE_432).
     pub const DCI_P3: ColorPrimaries = ColorPrimaries {
         red: Chromaticity { x: 0.680, y: 0.320 },
         green: Chromaticity { x: 0.265, y: 0.690 },
         blue: Chromaticity { x: 0.150, y: 0.060 },
     };
+
+    /// [Diplay P3](https://en.wikipedia.org/wiki/DCI-P3#Display_P3).
+    ///
+    /// This is the same as [`DCI_P3`](Self::DCI_P3),
+    /// [`SMPTE_431`](Self::SMPTE_431) and [`SMPTE_432`](Self::SMPTE_432).
+    pub const DISPLAY_P3: ColorPrimaries = Self::DCI_P3;
+
+    /// SMPTE RP 431-2 (2011).
+    ///
+    /// This is the same as [`DCI_P3`](Self::DCI_P3),
+    /// [`DISPLAY_P3`](Self::DISPLAY_P3) and [`SMPTE_432`](Self::SMPTE_432).
+    pub const SMPTE_431: ColorPrimaries = Self::DCI_P3;
+
+    /// SMPTE EG 432-1 (2010).
+    ///
+    /// This is the same as [`DCI_P3`](Self::DCI_P3),
+    /// [`DISPLAY_P3`](Self::DISPLAY_P3) and [`SMPTE_431`](Self::SMPTE_431).
+    pub const SMPTE_432: ColorPrimaries = Self::DCI_P3;
 
     /// [ProPhoto RGB](https://en.wikipedia.org/wiki/ProPhoto_RGB_color_space).
     pub const PRO_PHOTO_RGB: ColorPrimaries = ColorPrimaries {
@@ -229,16 +250,6 @@ impl ColorPrimaries {
         green: Chromaticity { x: 0.0, y: 1.0 },
         blue: Chromaticity { x: 0.0, y: 0.0 },
     };
-
-    /// SMPTE RP 431-2 (2011).
-    pub const SMPTE_431: ColorPrimaries = ColorPrimaries {
-        red: Chromaticity { x: 0.680, y: 0.320 },
-        green: Chromaticity { x: 0.265, y: 0.690 },
-        blue: Chromaticity { x: 0.150, y: 0.060 },
-    };
-
-    /// SMPTE EG 432-1 (2010)<br />
-    pub const SMPTE_432: ColorPrimaries = Self::SMPTE_431;
 
     /// EBU Tech. 3213-E (1975).
     pub const EBU_3213: ColorPrimaries = ColorPrimaries {

--- a/src/cicp.rs
+++ b/src/cicp.rs
@@ -26,55 +26,14 @@
  * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-use crate::err::CmsError;
-use crate::trc::{Trc, build_srgb_gamma_table, build_trc_table, curve_from_gamma};
-use crate::{Chromacity, pow};
+use crate::{
+    Chromaticity,
+    err::CmsError,
+    pow,
+    trc::{ToneReprCurve, build_srgb_gamma_table, build_trc_table, curve_from_gamma},
+};
+use bytemuck::{ByteEq, NoUninit};
 use std::convert::TryFrom;
-
-/// See [Rec. ITU-T H.273 (12/2016)](https://www.itu.int/rec/T-REC-H.273-201612-I/en) Table 2
-/// Values 0, 3, 13–21, 23–255 are all reserved so all map to the same variant
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum ColorPrimaries {
-    /// For future use by ITU-T | ISO/IEC
-    Reserved,
-    /// Rec. ITU-R BT.709-6<br />
-    /// Rec. ITU-R BT.1361-0 conventional colour gamut system and extended colour gamut system (historical)<br />
-    /// IEC 61966-2-1 sRGB or sYCC IEC 61966-2-4<br />
-    /// Society of Motion Picture and Television Engineers (MPTE) RP 177 (1993) Annex B<br />
-    Bt709 = 1,
-    /// Unspecified<br />
-    /// Image characteristics are unknown or are determined by the application.
-    Unspecified = 2,
-    /// Rec. ITU-R BT.470-6 System M (historical)<br />
-    /// United States National Television System Committee 1953 Recommendation for transmission standards for color television<br />
-    /// United States Federal Communications Commission (2003) Title 47 Code of Federal Regulations 73.682 (a) (20)<br />
-    Bt470M = 4,
-    /// Rec. ITU-R BT.470-6 System B, G (historical) Rec. ITU-R BT.601-7 625<br />
-    /// Rec. ITU-R BT.1358-0 625 (historical)<br />
-    /// Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM<br />
-    Bt470Bg = 5,
-    /// Rec. ITU-R BT.601-7 525<br />
-    /// Rec. ITU-R BT.1358-1 525 or 625 (historical) Rec. ITU-R BT.1700-0 NTSC<br />
-    /// SMPTE 170M (2004)<br />
-    /// (functionally the same as the value 7)<br />
-    Bt601 = 6,
-    /// SMPTE 240M (1999) (historical) (functionally the same as the value 6)<br />
-    Smpte240 = 7,
-    /// Generic film (colour filters using Illuminant C)<br />
-    GenericFilm = 8,
-    /// Rec. ITU-R BT.2020-2<br />
-    /// Rec. ITU-R BT.2100-0<br />
-    Bt2020 = 9,
-    /// SMPTE ST 428-1<br />
-    /// (CIE 1931 XYZ as in ISO 11664-1)<br />
-    Xyz = 10,
-    /// SMPTE RP 431-2 (2011)<br />
-    Smpte431 = 11,
-    /// SMPTE EG 432-1 (2010)<br />
-    Smpte432 = 12,
-    /// EBU Tech. 3213-E (1975)<br />
-    Ebu3213 = 22,
-}
 
 impl TryFrom<u8> for ColorPrimaries {
     type Error = CmsError;
@@ -82,123 +41,211 @@ impl TryFrom<u8> for ColorPrimaries {
     #[allow(unreachable_patterns)]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 | 3 | 13..=21 | 23..=255 => Ok(Self::Reserved),
-            1 => Ok(Self::Bt709),
-            2 => Ok(Self::Unspecified),
-            4 => Ok(Self::Bt470M),
-            5 => Ok(Self::Bt470Bg),
-            6 => Ok(Self::Bt601),
-            7 => Ok(Self::Smpte240),
-            8 => Ok(Self::GenericFilm),
-            9 => Ok(Self::Bt2020),
-            10 => Ok(Self::Xyz),
-            11 => Ok(Self::Smpte431),
-            12 => Ok(Self::Smpte432),
-            22 => Ok(Self::Ebu3213),
+            0 | 3 | 13..=21 | 23..=255 => Err(CmsError::UnsupportedColorPrimaries(value)),
+            1 => Ok(Self::BT_709),
+            2 => Err(CmsError::UnsupportedColorPrimaries(value)),
+            4 => Ok(Self::BT_470M),
+            5 => Ok(Self::BT_470BG),
+            6 => Ok(Self::BT_601),
+            7 => Ok(Self::SMPTE_240),
+            8 => Ok(Self::GENERIC_FILM),
+            9 => Ok(Self::BT_2020),
+            10 => Ok(Self::XYZ),
+            11 => Ok(Self::SMPTE_431),
+            12 => Ok(Self::SMPTE_432),
+            22 => Ok(Self::EBU_3213),
             _ => Err(CmsError::InvalidCicp),
         }
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct ChromacityTriple {
-    pub red: Chromacity,
-    pub green: Chromacity,
-    pub blue: Chromacity,
-}
-
-impl TryFrom<ColorPrimaries> for ChromacityTriple {
-    type Error = CmsError;
-
-    fn try_from(value: ColorPrimaries) -> Result<Self, Self::Error> {
-        let red;
-        let green;
-        let blue;
-
-        match value {
-            ColorPrimaries::Reserved => {
-                return Err(CmsError::UnsupportedColorPrimaries(value as u8));
-            }
-            ColorPrimaries::Bt709 => {
-                green = Chromacity { x: 0.300, y: 0.600 };
-                blue = Chromacity { x: 0.150, y: 0.060 };
-                red = Chromacity { x: 0.640, y: 0.330 };
-            }
-            ColorPrimaries::Unspecified => {
-                return Err(CmsError::UnsupportedColorPrimaries(value as u8));
-            }
-            ColorPrimaries::Bt470M => {
-                green = Chromacity { x: 0.21, y: 0.71 };
-                blue = Chromacity { x: 0.14, y: 0.08 };
-                red = Chromacity { x: 0.67, y: 0.33 };
-            }
-            ColorPrimaries::Bt470Bg => {
-                green = Chromacity { x: 0.29, y: 0.60 };
-                blue = Chromacity { x: 0.15, y: 0.06 };
-                red = Chromacity { x: 0.64, y: 0.33 };
-            }
-            ColorPrimaries::Bt601 | ColorPrimaries::Smpte240 => {
-                green = Chromacity { x: 0.310, y: 0.595 };
-                blue = Chromacity { x: 0.155, y: 0.070 };
-                red = Chromacity { x: 0.630, y: 0.340 };
-            }
-            ColorPrimaries::GenericFilm => {
-                green = Chromacity { x: 0.243, y: 0.692 };
-                blue = Chromacity { x: 0.145, y: 0.049 };
-                red = Chromacity { x: 0.681, y: 0.319 };
-            }
-            ColorPrimaries::Bt2020 => {
-                green = Chromacity { x: 0.170, y: 0.797 };
-                blue = Chromacity { x: 0.131, y: 0.046 };
-                red = Chromacity { x: 0.708, y: 0.292 };
-            }
-            ColorPrimaries::Xyz => {
-                green = Chromacity { x: 0.0, y: 1.0 };
-                blue = Chromacity { x: 0.0, y: 0.0 };
-                red = Chromacity { x: 1.0, y: 0.0 };
-            }
-            // These two share primaries, but have distinct white points
-            ColorPrimaries::Smpte431 | ColorPrimaries::Smpte432 => {
-                green = Chromacity { x: 0.265, y: 0.690 };
-                blue = Chromacity { x: 0.150, y: 0.060 };
-                red = Chromacity { x: 0.680, y: 0.320 };
-            }
-            ColorPrimaries::Ebu3213 => {
-                green = Chromacity { x: 0.295, y: 0.605 };
-                blue = Chromacity { x: 0.155, y: 0.077 };
-                red = Chromacity { x: 0.630, y: 0.340 };
-            }
+impl From<ColorPrimaries> for u8 {
+    fn from(value: ColorPrimaries) -> Self {
+        // TODO: this can be made into a match block once
+        // https://github.com/rust-lang/rust/issues/76560 is stabilized.
+        if ColorPrimaries::BT_709 == value {
+            1
+        } else if ColorPrimaries::BT_470M == value {
+            4
+        } else if ColorPrimaries::BT_470BG == value {
+            5
+        } else if ColorPrimaries::BT_601 == value {
+            6
+        } else if ColorPrimaries::SMPTE_240 == value {
+            7
+        } else if ColorPrimaries::GENERIC_FILM == value {
+            8
+        } else if ColorPrimaries::BT_2020 == value {
+            9
+        } else if ColorPrimaries::XYZ == value {
+            10
+        } else if ColorPrimaries::SMPTE_431 == value {
+            11
+        } else if ColorPrimaries::SMPTE_432 == value {
+            12
+        } else if ColorPrimaries::EBU_3213 == value {
+            22
+        } else {
+            // Values 0, 3, 13–21, 23–255 are all reserved so all map to the
+            // same variant.
+            0
         }
-
-        Ok(Self { red, green, blue })
     }
 }
 
-impl ColorPrimaries {
-    pub(crate) fn has_chromacity(self) -> bool {
-        self != Self::Reserved && self != Self::Unspecified
-    }
+#[derive(Clone, Copy, Debug, NoUninit, ByteEq)]
+#[repr(C)]
+pub struct ColorPrimaries {
+    pub red: Chromaticity,
+    pub green: Chromaticity,
+    pub blue: Chromaticity,
+}
 
-    pub(crate) fn white_point(self) -> Result<Chromacity, CmsError> {
-        Ok(match self {
-            Self::Reserved => return Err(CmsError::UnsupportedColorPrimaries(self as u8)),
-            Self::Bt709
-            | Self::Bt470Bg
-            | Self::Bt601
-            | Self::Smpte240
-            | Self::Bt2020
-            | Self::Smpte432
-            | Self::Ebu3213 => Chromacity::D65,
-            Self::Unspecified => return Err(CmsError::UnsupportedColorPrimaries(self as u8)),
-            Self::Bt470M => Chromacity { x: 0.310, y: 0.316 },
-            Self::GenericFilm => Chromacity { x: 0.310, y: 0.316 },
-            Self::Xyz => Chromacity {
-                x: 1. / 3.,
-                y: 1. / 3.,
-            },
-            Self::Smpte431 => Chromacity { x: 0.314, y: 0.351 },
-        })
-    }
+/// See [Rec. ITU-T H.273 (12/2016)](https://www.itu.int/rec/T-REC-H.273-201612-I/en) Table 2.
+impl ColorPrimaries {
+    /// [ACEScg](https://en.wikipedia.org/wiki/Academy_Color_Encoding_System#ACEScg).
+    pub const ACES_CG: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.713, y: 0.293 },
+        green: Chromaticity { x: 0.165, y: 0.830 },
+        blue: Chromaticity { x: 0.128, y: 0.044 },
+    };
+
+    /// [ACES2065-1](https://en.wikipedia.org/wiki/Academy_Color_Encoding_System#ACES2065-1).
+    pub const ACES_2065_1: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity {
+            x: 0.7347,
+            y: 0.2653,
+        },
+        green: Chromaticity {
+            x: 0.0000,
+            y: 1.0000,
+        },
+        blue: Chromaticity {
+            x: 0.0001,
+            y: -0.0770,
+        },
+    };
+
+    /// [Adobe RGB](https://en.wikipedia.org/wiki/DCI-P3) (1998).
+    pub const ADOBE_RGB: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.64, y: 0.33 },
+        green: Chromaticity { x: 0.21, y: 0.71 },
+        blue: Chromaticity { x: 0.15, y: 0.06 },
+    };
+
+    /// [DCI-P3](https://en.wikipedia.org/wiki/DCI-P3).
+    pub const DCI_P3: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.680, y: 0.320 },
+        green: Chromaticity { x: 0.265, y: 0.690 },
+        blue: Chromaticity { x: 0.150, y: 0.060 },
+    };
+
+    /// [ProPhoto RGB](https://en.wikipedia.org/wiki/ProPhoto_RGB_color_space).
+    pub const PRO_PHOTO_RGB: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity {
+            x: 0.734699,
+            y: 0.265301,
+        },
+        green: Chromaticity {
+            x: 0.159597,
+            y: 0.840403,
+        },
+        blue: Chromaticity {
+            x: 0.036598,
+            y: 0.000105,
+        },
+    };
+
+    /// Rec. ITU-R BT.709-6
+    ///
+    /// Rec. ITU-R BT.1361-0 conventional colour gamut system and extended
+    /// colour gamut system (historical).
+    ///
+    /// IEC 61966-2-1 sRGB or sYCC IEC 61966-2-4).
+    ///
+    /// Society of Motion Picture and Television Engineers (MPTE) RP 177 (1993) Annex B.
+    pub const BT_709: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.64, y: 0.33 },
+        green: Chromaticity { x: 0.30, y: 0.60 },
+        blue: Chromaticity { x: 0.15, y: 0.06 },
+    };
+
+    /// Rec. ITU-R BT.470-6 System M (historical).
+    ///
+    /// United States National Television System Committee 1953 Recommendation
+    /// for transmission standards for color television.
+    ///
+    /// United States Federal Communications Commission (2003) Title 47 Code of
+    /// Federal Regulations 73.682 (a) (20).
+    pub const BT_470M: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.67, y: 0.33 },
+        green: Chromaticity { x: 0.21, y: 0.71 },
+        blue: Chromaticity { x: 0.14, y: 0.08 },
+    };
+
+    /// Rec. ITU-R BT.470-6 System B, G (historical) Rec. ITU-R BT.601-7 625.
+    ///
+    /// Rec. ITU-R BT.1358-0 625 (historical).
+    /// Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM.
+    pub const BT_470BG: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.64, y: 0.33 },
+        green: Chromaticity { x: 0.29, y: 0.60 },
+        blue: Chromaticity { x: 0.15, y: 0.06 },
+    };
+
+    /// Rec. ITU-R BT.601-7 525.
+    ///
+    /// Rec. ITU-R BT.1358-1 525 or 625 (historical) Rec. ITU-R BT.1700-0 NTSC.
+    ///
+    /// SMPTE 170M (2004) (functionally the same as the [`BT_240M`]).
+    pub const BT_601: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.630, y: 0.340 },
+        green: Chromaticity { x: 0.310, y: 0.595 },
+        blue: Chromaticity { x: 0.155, y: 0.070 },
+    };
+
+    /// SMPTE 240M (1999) (historical) (functionally the same as [`BT_601`]).
+    pub const SMPTE_240: ColorPrimaries = Self::BT_601;
+
+    /// Generic film (colour filters using Illuminant C).
+    pub const GENERIC_FILM: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.681, y: 0.319 },
+        green: Chromaticity { x: 0.243, y: 0.692 },
+        blue: Chromaticity { x: 0.145, y: 0.049 },
+    };
+
+    /// Rec. ITU-R BT.2020-2.
+    ///
+    /// Rec. ITU-R BT.2100-0.
+    pub const BT_2020: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.708, y: 0.292 },
+        green: Chromaticity { x: 0.170, y: 0.797 },
+        blue: Chromaticity { x: 0.131, y: 0.046 },
+    };
+
+    /// SMPTE ST 428-1 (CIE 1931 XYZ as in ISO 11664-1).
+    pub const XYZ: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 1.0, y: 0.0 },
+        green: Chromaticity { x: 0.0, y: 1.0 },
+        blue: Chromaticity { x: 0.0, y: 0.0 },
+    };
+
+    /// SMPTE RP 431-2 (2011).
+    pub const SMPTE_431: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.680, y: 0.320 },
+        green: Chromaticity { x: 0.265, y: 0.690 },
+        blue: Chromaticity { x: 0.150, y: 0.060 },
+    };
+
+    /// SMPTE EG 432-1 (2010)<br />
+    pub const SMPTE_432: ColorPrimaries = Self::SMPTE_431;
+
+    /// EBU Tech. 3213-E (1975).
+    pub const EBU_3213: ColorPrimaries = ColorPrimaries {
+        red: Chromaticity { x: 0.630, y: 0.340 },
+        green: Chromaticity { x: 0.295, y: 0.605 },
+        blue: Chromaticity { x: 0.155, y: 0.077 },
+    };
 }
 
 /// See [Rec. ITU-T H.273 (12/2016)](https://www.itu.int/rec/T-REC-H.273-201612-I/en) Table 3
@@ -284,18 +331,7 @@ impl TryFrom<u8> for TransferCharacteristics {
     }
 }
 
-impl TransferCharacteristics {
-    pub(crate) fn has_transfer_curve(self) -> bool {
-        self != Self::Reserved
-            && self != Self::Unspecified
-            && self != Self::Smpte240
-            && self != Self::Iec61966
-            && self != Self::Bt1361
-            && self != Self::Smpte428
-    }
-}
-
-impl TryFrom<TransferCharacteristics> for Trc {
+impl TryFrom<TransferCharacteristics> for ToneReprCurve {
     type Error = CmsError;
     /// See [ICC.1:2010](https://www.color.org/specification/ICC1v43_2010-12.pdf)
     /// See [Rec. ITU-R BT.2100-2](https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2100-2-201807-I!!PDF-E.pdf)
@@ -354,7 +390,7 @@ impl TryFrom<TransferCharacteristics> for Trc {
                 const C: Float = 1. / LINEAR_CONF;
                 const D: Float = LINEAR_CONF * BETA;
 
-                Trc::Parametric(vec![G, A, B, C, D])
+                ToneReprCurve::Parametric(vec![G, A, B, C, D])
             }
             TransferCharacteristics::Unspecified => {
                 return Err(CmsError::UnsupportedTrc(value as u8));
@@ -377,7 +413,7 @@ impl TryFrom<TransferCharacteristics> for Trc {
                 //
                 // Lc = 10^(2*V - 2)  for 1 >= V >= 0
                 let table = build_trc_table(NUM_TRC_TABLE_ENTRIES, |v| pow(10f64, 2. * v - 2.));
-                Trc::Lut(table)
+                ToneReprCurve::Lut(table)
             }
             TransferCharacteristics::Log100sqrt10 => {
                 // The opto-electronic transfer characteristic function (OETF)
@@ -390,7 +426,7 @@ impl TryFrom<TransferCharacteristics> for Trc {
                 //
                 // Lc = 10^(2.5*V - 2.5)  for 1 >= V >= 0
                 let table = build_trc_table(NUM_TRC_TABLE_ENTRIES, |v| pow(10f64, 2.5 * v - 2.5));
-                Trc::Lut(table)
+                ToneReprCurve::Lut(table)
             }
             TransferCharacteristics::Iec61966 => {
                 return Err(CmsError::UnsupportedTrc(value as u8));
@@ -398,7 +434,7 @@ impl TryFrom<TransferCharacteristics> for Trc {
             TransferCharacteristics::Bt1361 => return Err(CmsError::UnsupportedTrc(value as u8)),
             TransferCharacteristics::Srgb => {
                 // Should we prefer this or curveType::Parametric?
-                Trc::Lut(build_srgb_gamma_table(NUM_TRC_TABLE_ENTRIES))
+                ToneReprCurve::Lut(build_srgb_gamma_table(NUM_TRC_TABLE_ENTRIES))
             }
 
             TransferCharacteristics::Smpte2084 => {
@@ -421,7 +457,7 @@ impl TryFrom<TransferCharacteristics> for Trc {
                         1. / N,
                     )
                 });
-                Trc::Lut(table)
+                ToneReprCurve::Lut(table)
             }
             TransferCharacteristics::Smpte428 => {
                 return Err(CmsError::UnsupportedTrc(value as u8));
@@ -450,7 +486,7 @@ impl TryFrom<TransferCharacteristics> for Trc {
                         (pow(std::f64::consts::E, (x - C) / A) + B) / 12.
                     }
                 });
-                Trc::Lut(table)
+                ToneReprCurve::Lut(table)
             }
         })
     }

--- a/src/cicp.rs
+++ b/src/cicp.rs
@@ -197,14 +197,14 @@ impl ColorPrimaries {
     ///
     /// Rec. ITU-R BT.1358-1 525 or 625 (historical) Rec. ITU-R BT.1700-0 NTSC.
     ///
-    /// SMPTE 170M (2004) (functionally the same as the [`BT_240M`]).
+    /// SMPTE 170M (2004) (functionally the same as the [`SMPTE_240`](Self::SMPTE_240)).
     pub const BT_601: ColorPrimaries = ColorPrimaries {
         red: Chromaticity { x: 0.630, y: 0.340 },
         green: Chromaticity { x: 0.310, y: 0.595 },
         blue: Chromaticity { x: 0.155, y: 0.070 },
     };
 
-    /// SMPTE 240M (1999) (historical) (functionally the same as [`BT_601`]).
+    /// SMPTE 240M (1999) (historical) (functionally the same as [`BT_601`](Self::BT_601)).
     pub const SMPTE_240: ColorPrimaries = Self::BT_601;
 
     /// Generic film (colour filters using Illuminant C).

--- a/src/cicp.rs
+++ b/src/cicp.rs
@@ -35,6 +35,14 @@ use crate::{
 use bytemuck::{ByteEq, NoUninit};
 use std::convert::TryFrom;
 
+#[derive(Clone, Copy, Debug, NoUninit, ByteEq)]
+#[repr(C)]
+pub struct ColorPrimaries {
+    pub red: Chromaticity,
+    pub green: Chromaticity,
+    pub blue: Chromaticity,
+}
+
 impl TryFrom<u8> for ColorPrimaries {
     type Error = CmsError;
 
@@ -91,14 +99,6 @@ impl From<ColorPrimaries> for u8 {
             0
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, NoUninit, ByteEq)]
-#[repr(C)]
-pub struct ColorPrimaries {
-    pub red: Chromaticity,
-    pub green: Chromaticity,
-    pub blue: Chromaticity,
 }
 
 /// See [Rec. ITU-T H.273 (12/2016)](https://www.itu.int/rec/T-REC-H.273-201612-I/en) Table 2.

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -27,16 +27,17 @@
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 use crate::math::copysign;
-use crate::trc::{Trc, curve_from_gamma};
+use crate::trc::{ToneReprCurve, curve_from_gamma};
 use crate::{
-    Chromacity, ChromacityTriple, ColorPrimaries, ColorProfile, DataColorSpace, LocalizableString,
-    ProfileClass, ProfileText, RenderingIntent, XyY, Xyz, exp, floor, pow,
+    Chromaticity, ColorPrimaries, ColorProfile, DataColorSpace, LocalizableString, ProfileClass,
+    ProfileText, RenderingIntent, XyY, exp, floor, pow,
 };
-/* from lcms: cmsWhitePointFromTemp */
-/* tempK must be >= 4000. and <= 25000.
- * Invalid values of tempK will return
- * (x,y,Y) = (-1.0, -1.0, -1.0)
- * similar to argyll: icx_DTEMP2XYZ() */
+
+/// From lcms: `cmsWhitePointFromTemp`
+/// tempK must be >= 4000. and <= 25000.
+/// Invalid values of tempK will return
+/// (x,y,Y) = (-1.0, -1.0, -1.0)
+/// similar to argyll: `icx_DTEMP2XYZ()`
 const fn white_point_from_temperature(temp_k: i32) -> XyY {
     let mut white_point = XyY {
         x: 0f32,
@@ -73,17 +74,9 @@ const fn white_point_from_temperature(temp_k: i32) -> XyY {
     white_point
 }
 
-pub const fn white_point_srgb() -> XyY {
-    white_point_from_temperature(6504)
-}
-
-pub const fn white_point_d50() -> XyY {
-    white_point_from_temperature(5003)
-}
-
-pub const fn white_point_d60() -> XyY {
-    white_point_from_temperature(6000)
-}
+pub const WHITE_POINT_D50: XyY = white_point_from_temperature(5003);
+pub const WHITE_POINT_D60: XyY = white_point_from_temperature(6000);
+pub const WHITE_POINT_D65: XyY = white_point_from_temperature(6504);
 
 // https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2100-2-201807-I!!PDF-F.pdf
 // Perceptual Quantization / SMPTE standard ST.2084
@@ -186,12 +179,11 @@ pub const HLG_LUT_TABLE: [u16; 4096] = build_trc_table_hlg();
 impl ColorProfile {
     /// Creates new sRGB profile
     pub fn new_srgb() -> ColorProfile {
-        let primaries = ChromacityTriple::try_from(ColorPrimaries::Bt709).unwrap();
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, primaries);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::BT_709);
 
-        let curve = Trc::Parametric(vec![2.4, 1. / 1.055, 0.055 / 1.055, 1. / 12.92, 0.04045]);
+        let curve =
+            ToneReprCurve::Parametric(vec![2.4, 1. / 1.055, 0.055 / 1.055, 1. / 12.92, 0.04045]);
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
         profile.green_trc = Some(curve);
@@ -199,8 +191,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -216,14 +208,8 @@ impl ColorProfile {
 
     /// Creates new Adobe RGB profile
     pub fn new_adobe_rgb() -> ColorProfile {
-        let triplet = ChromacityTriple {
-            red: Chromacity::new(0.6400, 0.3300),
-            green: Chromacity::new(0.2100, 0.7100),
-            blue: Chromacity::new(0.1500, 0.0600),
-        };
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, triplet);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::ADOBE_RGB);
 
         let curve = curve_from_gamma(2.19921875f32);
         profile.red_trc = Some(curve.clone());
@@ -233,8 +219,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -250,12 +236,11 @@ impl ColorProfile {
 
     /// Creates new Display P3 profile
     pub fn new_display_p3() -> ColorProfile {
-        let primaries = ChromacityTriple::try_from(ColorPrimaries::Smpte432).unwrap();
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, primaries);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::SMPTE_432);
 
-        let curve = Trc::Parametric(vec![2.4, 1. / 1.055, 0.055 / 1.055, 1. / 12.92, 0.04045]);
+        let curve =
+            ToneReprCurve::Parametric(vec![2.4, 1. / 1.055, 0.055 / 1.055, 1. / 12.92, 0.04045]);
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
         profile.green_trc = Some(curve);
@@ -263,8 +248,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -280,12 +265,10 @@ impl ColorProfile {
 
     /// Creates new Display P3 PQ profile
     pub fn new_display_p3_pq() -> ColorProfile {
-        let primaries = ChromacityTriple::try_from(ColorPrimaries::Smpte432).unwrap();
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, primaries);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::SMPTE_432);
 
-        let curve = Trc::Lut(PQ_LUT_TABLE.to_vec());
+        let curve = ToneReprCurve::Lut(PQ_LUT_TABLE.to_vec());
 
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
@@ -294,8 +277,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -311,14 +294,8 @@ impl ColorProfile {
 
     /// Creates new DCI P3 profile
     pub fn new_dci_p3() -> ColorProfile {
-        let triplet = ChromacityTriple {
-            red: Chromacity::new(0.680, 0.320),
-            green: Chromacity::new(0.265, 0.690),
-            blue: Chromacity::new(0.150, 0.060),
-        };
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, triplet);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::DCI_P3);
 
         let curve = curve_from_gamma(2.6f32);
         profile.red_trc = Some(curve.clone());
@@ -328,8 +305,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -345,14 +322,8 @@ impl ColorProfile {
 
     /// Creates new ProPhoto RGB profile
     pub fn new_pro_photo_rgb() -> ColorProfile {
-        let triplet = ChromacityTriple {
-            red: Chromacity::new(0.734699, 0.265301),
-            green: Chromacity::new(0.159597, 0.840403),
-            blue: Chromacity::new(0.036598, 0.000105),
-        };
-        const WHITE_POINT: XyY = white_point_d50();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, triplet);
+        profile.update_rgb_colorimetry(WHITE_POINT_D50, ColorPrimaries::PRO_PHOTO_RGB);
 
         let curve = curve_from_gamma(1.8f32);
         profile.red_trc = Some(curve.clone());
@@ -362,8 +333,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D50.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D50.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -379,12 +350,11 @@ impl ColorProfile {
 
     /// Creates new Bt.2020 profile
     pub fn new_bt2020() -> ColorProfile {
-        let primaries = ChromacityTriple::try_from(ColorPrimaries::Bt2020).unwrap();
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, primaries);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::BT_2020);
 
-        let curve = Trc::Parametric(vec![2.4, 1. / 1.055, 0.055 / 1.055, 1. / 12.92, 0.04045]);
+        let curve =
+            ToneReprCurve::Parametric(vec![2.4, 1. / 1.055, 0.055 / 1.055, 1. / 12.92, 0.04045]);
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
         profile.green_trc = Some(curve);
@@ -392,8 +362,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -409,12 +379,10 @@ impl ColorProfile {
 
     /// Creates new Bt.2020 PQ profile
     pub fn new_bt2020_pq() -> ColorProfile {
-        let primaries = ChromacityTriple::try_from(ColorPrimaries::Bt2020).unwrap();
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, primaries);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::BT_2020);
 
-        let curve = Trc::Lut(PQ_LUT_TABLE.to_vec());
+        let curve = ToneReprCurve::Lut(PQ_LUT_TABLE.to_vec());
 
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
@@ -423,8 +391,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -440,12 +408,10 @@ impl ColorProfile {
 
     /// Creates new Bt.2020 HLG profile
     pub fn new_bt2020_hlg() -> ColorProfile {
-        let primaries = ChromacityTriple::try_from(ColorPrimaries::Bt2020).unwrap();
-        const WHITE_POINT: XyY = white_point_srgb();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, primaries);
+        profile.update_rgb_colorimetry(WHITE_POINT_D65, ColorPrimaries::BT_2020);
 
-        let curve = Trc::Lut(HLG_LUT_TABLE.to_vec());
+        let curve = ToneReprCurve::Lut(HLG_LUT_TABLE.to_vec());
 
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
@@ -454,8 +420,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(Chromacity::D65.to_xyz());
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(Chromaticity::D65.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -476,8 +442,8 @@ impl ColorProfile {
             profile_class: ProfileClass::DisplayDevice,
             rendering_intent: RenderingIntent::Perceptual,
             color_space: DataColorSpace::Gray,
-            media_white_point: Some(Chromacity::D65.to_xyz()),
-            white_point: Chromacity::D50.to_xyz(),
+            media_white_point: Some(Chromaticity::D65.to_xyz()),
+            white_point: Chromaticity::D50.to_xyz(),
             copyright: Some(ProfileText::Localizable(vec![LocalizableString::new(
                 "en".to_string(),
                 "US".to_string(),
@@ -488,18 +454,11 @@ impl ColorProfile {
     }
 
     /// Creates new ACES 2065-1/AP0 profile
-    pub fn new_aces_ap0_linear() -> ColorProfile {
-        let triplet = ChromacityTriple {
-            red: Chromacity::new(0.7347, 0.2653),
-            green: Chromacity::new(0.0000, 1.0000),
-            blue: Chromacity::new(0.0001, -0.0770),
-        };
-        const WHITE_POINT: XyY = white_point_d60();
-        const WHITE_POINT_XYZ: Xyz = WHITE_POINT.to_xyz();
+    pub fn new_aces_aces_2065_1_linear() -> ColorProfile {
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, triplet);
+        profile.update_rgb_colorimetry(WHITE_POINT_D60, ColorPrimaries::ACES_2065_1);
 
-        let curve = Trc::Lut(vec![]);
+        let curve = ToneReprCurve::Lut(vec![]);
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
         profile.green_trc = Some(curve);
@@ -507,12 +466,12 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(WHITE_POINT_XYZ);
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(WHITE_POINT_D60.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
-            "ACES 2065-1/AP0".to_string(),
+            "ACES 2065-1".to_string(),
         )]));
         profile.copyright = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
@@ -524,17 +483,10 @@ impl ColorProfile {
 
     /// Creates new ACEScg profile
     pub fn new_aces_cg_linear() -> ColorProfile {
-        let triplet = ChromacityTriple {
-            red: Chromacity::new(0.713, 0.293),
-            green: Chromacity::new(0.165, 0.830),
-            blue: Chromacity::new(0.128, 0.044),
-        };
-        const WHITE_POINT: XyY = white_point_d60();
-        const WHITE_POINT_XYZ: Xyz = WHITE_POINT.to_xyz();
         let mut profile = ColorProfile::default();
-        profile.update_rgb_colorimetry(WHITE_POINT, triplet);
+        profile.update_rgb_colorimetry(WHITE_POINT_D60, ColorPrimaries::ACES_CG);
 
-        let curve = Trc::Lut(vec![]);
+        let curve = ToneReprCurve::Lut(vec![]);
         profile.red_trc = Some(curve.clone());
         profile.blue_trc = Some(curve.clone());
         profile.green_trc = Some(curve);
@@ -542,8 +494,8 @@ impl ColorProfile {
         profile.rendering_intent = RenderingIntent::Perceptual;
         profile.color_space = DataColorSpace::Rgb;
         profile.pcs = DataColorSpace::Xyz;
-        profile.media_white_point = Some(WHITE_POINT_XYZ);
-        profile.white_point = Chromacity::D50.to_xyz();
+        profile.media_white_point = Some(WHITE_POINT_D60.to_xyz());
+        profile.white_point = Chromaticity::D50.to_xyz();
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -29,8 +29,9 @@
 use crate::math::copysign;
 use crate::trc::{ToneReprCurve, curve_from_gamma};
 use crate::{
-    Chromaticity, ColorPrimaries, ColorProfile, DataColorSpace, LocalizableString, ProfileClass,
-    ProfileText, RenderingIntent, XyY, exp, floor, pow,
+    Chromaticity, CicpColorPrimaries, CicpProfile, ColorPrimaries, ColorProfile, DataColorSpace,
+    LocalizableString, MatrixCoefficients, ProfileClass, ProfileText, RenderingIntent,
+    TransferCharacteristics, XyY, exp, floor, pow,
 };
 
 /// From lcms: `cmsWhitePointFromTemp`
@@ -193,6 +194,12 @@ impl ColorProfile {
         profile.pcs = DataColorSpace::Xyz;
         profile.media_white_point = Some(Chromaticity::D65.to_xyz());
         profile.white_point = Chromaticity::D50.to_xyz();
+        profile.cicp = Some(CicpProfile {
+            color_primaries: CicpColorPrimaries::Bt709,
+            transfer_characteristics: TransferCharacteristics::Srgb,
+            matrix_coefficients: MatrixCoefficients::Bt709,
+            full_range: false,
+        });
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -250,6 +257,12 @@ impl ColorProfile {
         profile.pcs = DataColorSpace::Xyz;
         profile.media_white_point = Some(Chromaticity::D65.to_xyz());
         profile.white_point = Chromaticity::D50.to_xyz();
+        profile.cicp = Some(CicpProfile {
+            color_primaries: CicpColorPrimaries::Smpte431,
+            transfer_characteristics: TransferCharacteristics::Srgb,
+            matrix_coefficients: MatrixCoefficients::Bt709,
+            full_range: false,
+        });
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -279,6 +292,12 @@ impl ColorProfile {
         profile.pcs = DataColorSpace::Xyz;
         profile.media_white_point = Some(Chromaticity::D65.to_xyz());
         profile.white_point = Chromaticity::D50.to_xyz();
+        profile.cicp = Some(CicpProfile {
+            color_primaries: CicpColorPrimaries::Smpte431,
+            transfer_characteristics: TransferCharacteristics::Smpte2084,
+            matrix_coefficients: MatrixCoefficients::Bt709,
+            full_range: false,
+        });
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -307,6 +326,12 @@ impl ColorProfile {
         profile.pcs = DataColorSpace::Xyz;
         profile.media_white_point = Some(Chromaticity::D65.to_xyz());
         profile.white_point = Chromaticity::D50.to_xyz();
+        profile.cicp = Some(CicpProfile {
+            color_primaries: CicpColorPrimaries::Smpte432,
+            transfer_characteristics: TransferCharacteristics::Srgb,
+            matrix_coefficients: MatrixCoefficients::Bt709,
+            full_range: false,
+        });
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -393,6 +418,12 @@ impl ColorProfile {
         profile.pcs = DataColorSpace::Xyz;
         profile.media_white_point = Some(Chromaticity::D65.to_xyz());
         profile.white_point = Chromaticity::D50.to_xyz();
+        profile.cicp = Some(CicpProfile {
+            color_primaries: CicpColorPrimaries::Bt2020,
+            transfer_characteristics: TransferCharacteristics::Smpte2084,
+            matrix_coefficients: MatrixCoefficients::Bt709,
+            full_range: false,
+        });
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),
@@ -422,6 +453,12 @@ impl ColorProfile {
         profile.pcs = DataColorSpace::Xyz;
         profile.media_white_point = Some(Chromaticity::D65.to_xyz());
         profile.white_point = Chromaticity::D50.to_xyz();
+        profile.cicp = Some(CicpProfile {
+            color_primaries: CicpColorPrimaries::Bt2020,
+            transfer_characteristics: TransferCharacteristics::Hlg,
+            matrix_coefficients: MatrixCoefficients::Bt709,
+            full_range: false,
+        });
         profile.description = Some(ProfileText::Localizable(vec![LocalizableString::new(
             "en".to_string(),
             "US".to_string(),

--- a/src/jzazbz.rs
+++ b/src/jzazbz.rs
@@ -71,11 +71,11 @@ fn perceptual_quantizer_inverse(x: f32) -> f32 {
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Default)]
 /// Represents Jzazbz
 pub struct Jzazbz {
-    /// Jz(lightness) generally expects to be between [0;1]
+    /// Jz(lightness) generally expects to be between `0.0..1.0`.
     pub jz: f32,
-    /// Az generally expects to be between [-0.5;0.5]
+    /// Az generally expects to be between `-0.5..0.5`.
     pub az: f32,
-    /// Bz generally expects to be between [-0.5;0.5]
+    /// Bz generally expects to be between `-0.5..0.5`.
     pub bz: f32,
 }
 

--- a/src/jzczhz.rs
+++ b/src/jzczhz.rs
@@ -38,11 +38,11 @@ use std::ops::{
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
 pub struct Jzczhz {
-    /// Jz(lightness) generally expects to be between [0;1]
+    /// Jz(lightness) generally expects to be between `0.0..1.0`.
     pub jz: f32,
-    /// Cz generally expects to be between [-1;1]
+    /// Cz generally expects to be between `-1.0..1.0`.
     pub cz: f32,
-    /// Hz generally expects to be between [-1;1]
+    /// Hz generally expects to be between `-1.0..1.0`.
     pub hz: f32,
 }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -27,7 +27,7 @@
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 use crate::math::cbrtf;
-use crate::{Chromacity, Xyz};
+use crate::{Chromaticity, Xyz};
 
 /// Holds CIE LAB values
 #[repr(C)]
@@ -77,7 +77,7 @@ impl Lab {
     /// Converts to CIE Lab from CIE XYZ for PCS encoding
     #[inline]
     pub const fn from_pcs_xyz(xyz: Xyz) -> Self {
-        const WP: Xyz = Chromacity::D50.to_xyz();
+        const WP: Xyz = Chromaticity::D50.to_xyz();
         let device_x = (xyz.x as f64 * (1.0f64 + 32767.0f64 / 32768.0f64) / WP.x as f64) as f32;
         let device_y = (xyz.y as f64 * (1.0f64 + 32767.0f64 / 32768.0f64) / WP.y as f64) as f32;
         let device_z = (xyz.z as f64 * (1.0f64 + 32767.0f64 / 32768.0f64) / WP.z as f64) as f32;
@@ -99,7 +99,7 @@ impl Lab {
     /// Converts to CIE Lab from CIE XYZ
     #[inline]
     pub const fn from_xyz(xyz: Xyz) -> Self {
-        const WP: Xyz = Chromacity::D50.to_xyz();
+        const WP: Xyz = Chromaticity::D50.to_xyz();
         let device_x = (xyz.x as f64 * (1.0f64 + 32767.0f64 / 32768.0f64) / WP.x as f64) as f32;
         let device_y = (xyz.y as f64 * (1.0f64 + 32767.0f64 / 32768.0f64) / WP.y as f64) as f32;
         let device_z = (xyz.z as f64 * (1.0f64 + 32767.0f64 / 32768.0f64) / WP.z as f64) as f32;
@@ -124,7 +124,7 @@ impl Lab {
 
         let y = (device_l + 16.0) / 116.0;
 
-        const WP: Xyz = Chromacity::D50.to_xyz();
+        const WP: Xyz = Chromaticity::D50.to_xyz();
 
         let x = f_1(y + 0.002 * device_a) * WP.x;
         let y1 = f_1(y) * WP.y;
@@ -145,7 +145,7 @@ impl Lab {
 
         let y = (device_l + 16.0) / 116.0;
 
-        const WP: Xyz = Chromacity::D50.to_xyz();
+        const WP: Xyz = Chromaticity::D50.to_xyz();
 
         let x = f_1(y + 0.002 * device_a) * WP.x;
         let y1 = f_1(y) * WP.y;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod trc;
 mod writer;
 mod yrg;
 
-pub use cicp::{ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
+pub use cicp::{CicpColorPrimaries, ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
 pub use dat::ColorDateTime;
 pub use defaults::{
     HLG_LUT_TABLE, PQ_LUT_TABLE, WHITE_POINT_D50, WHITE_POINT_D60, WHITE_POINT_D65,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,10 @@ mod trc;
 mod writer;
 mod yrg;
 
-pub use cicp::{ChromacityTriple, ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
+pub use cicp::{ColorPrimaries, MatrixCoefficients, TransferCharacteristics};
 pub use dat::ColorDateTime;
 pub use defaults::{
-    HLG_LUT_TABLE, PQ_LUT_TABLE, white_point_d50, white_point_d60, white_point_srgb,
+    HLG_LUT_TABLE, PQ_LUT_TABLE, WHITE_POINT_D50, WHITE_POINT_D60, WHITE_POINT_D65,
 };
 pub use err::CmsError;
 pub use gamut::{
@@ -79,7 +79,7 @@ pub use math::{
     powf, rounding_div_ceil, sinf, sqrtf,
 };
 pub use matrix::{
-    BT2020_MATRIX, Chromacity, DISPLAY_P3_MATRIX, Matrix3f, Matrix4f, SRGB_MATRIX, Vector3,
+    BT2020_MATRIX, Chromaticity, DISPLAY_P3_MATRIX, Matrix3f, Matrix4f, SRGB_MATRIX, Vector3,
     Vector3f, Vector3i, Vector3u, Vector4, Vector4f, XyY, Xyz,
 };
 pub use nd_array::{Array3D, Array4D};
@@ -96,5 +96,5 @@ pub use transform::{
     InPlaceStage, Layout, Stage, Transform8BitExecutor, Transform16BitExecutor, TransformExecutor,
     TransformOptions,
 };
-pub use trc::{Trc, curve_from_gamma};
+pub use trc::{ToneReprCurve, curve_from_gamma};
 pub use yrg::{Ych, Yrg, cie_y_1931_to_cie_y_2006};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub use cicp::{CicpColorPrimaries, ColorPrimaries, MatrixCoefficients, TransferC
 pub use dat::ColorDateTime;
 pub use defaults::{
     HLG_LUT_TABLE, PQ_LUT_TABLE, WHITE_POINT_D50, WHITE_POINT_D60, WHITE_POINT_D65,
+    WHITE_POINT_DCI_P3,
 };
 pub use err::CmsError;
 pub use gamut::{

--- a/src/luv.rs
+++ b/src/luv.rs
@@ -54,18 +54,18 @@ pub struct LCh {
 }
 
 use crate::math::cbrtf;
-use crate::{Chromacity, Lab, Xyz, atan2f, const_hypotf, cosf, hypotf, powf, sinf};
+use crate::{Chromaticity, Lab, Xyz, atan2f, const_hypotf, cosf, hypotf, powf, sinf};
 use num_traits::Pow;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-pub(crate) const LUV_WHITE_U_PRIME: f32 = 4.0f32 * Chromacity::D50.to_xyz().y
-    / (Chromacity::D50.to_xyz().x
-        + 15.0 * Chromacity::D50.to_xyz().y
-        + 3.0 * Chromacity::D50.to_xyz().z);
-pub(crate) const LUV_WHITE_V_PRIME: f32 = 9.0f32 * Chromacity::D50.to_xyz().y
-    / (Chromacity::D50.to_xyz().x
-        + 15.0 * Chromacity::D50.to_xyz().y
-        + 3.0 * Chromacity::D50.to_xyz().z);
+pub(crate) const LUV_WHITE_U_PRIME: f32 = 4.0f32 * Chromaticity::D50.to_xyz().y
+    / (Chromaticity::D50.to_xyz().x
+        + 15.0 * Chromaticity::D50.to_xyz().y
+        + 3.0 * Chromaticity::D50.to_xyz().z);
+pub(crate) const LUV_WHITE_V_PRIME: f32 = 9.0f32 * Chromaticity::D50.to_xyz().y
+    / (Chromaticity::D50.to_xyz().x
+        + 15.0 * Chromaticity::D50.to_xyz().y
+        + 3.0 * Chromaticity::D50.to_xyz().z);
 
 pub(crate) const LUV_CUTOFF_FORWARD_Y: f32 = (6f32 / 29f32) * (6f32 / 29f32) * (6f32 / 29f32);
 pub(crate) const LUV_MULTIPLIER_FORWARD_Y: f32 = (29f32 / 3f32) * (29f32 / 3f32) * (29f32 / 3f32);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -30,6 +30,7 @@ use crate::err::CmsError;
 use crate::math::FusedMultiplyAdd;
 use crate::mlaf::mlaf;
 use crate::profile::s15_fixed16_number_to_float;
+use bytemuck::NoUninit;
 use num_traits::{AsPrimitive, MulAdd};
 use std::ops::{Add, Div, Mul, Sub};
 
@@ -743,13 +744,14 @@ impl XyY {
     }
 }
 
-#[derive(Clone, Debug, Copy)]
-pub struct Chromacity {
+#[derive(Clone, Debug, Copy, NoUninit)]
+#[repr(C)]
+pub struct Chromaticity {
     pub x: f32,
     pub y: f32,
 }
 
-impl Chromacity {
+impl Chromaticity {
     #[inline]
     pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
@@ -773,18 +775,18 @@ impl Chromacity {
         }
     }
 
-    pub const D65: Chromacity = Chromacity {
+    pub const D65: Chromaticity = Chromaticity {
         x: 0.31272,
         y: 0.32903,
     };
 
-    pub const D50: Chromacity = Chromacity {
+    pub const D50: Chromaticity = Chromaticity {
         x: 0.34567,
         y: 0.35850,
     };
 }
 
-impl TryFrom<Xyz> for Chromacity {
+impl TryFrom<Xyz> for Chromaticity {
     type Error = CmsError;
 
     #[inline]
@@ -797,12 +799,12 @@ impl TryFrom<Xyz> for Chromacity {
         }
         let rec = 1f32 / (xyz.x + xyz.y + xyz.z);
 
-        let chromacity_x = xyz.x * rec;
-        let chromacity_y = xyz.y * rec;
+        let chromaticity_x = xyz.x * rec;
+        let chromaticity_y = xyz.y * rec;
 
-        Ok(Chromacity {
-            x: chromacity_x,
-            y: chromacity_y,
+        Ok(Chromaticity {
+            x: chromaticity_x,
+            y: chromaticity_y,
         })
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -518,7 +518,6 @@ impl Matrix3f {
     #[inline]
     pub const fn inverse_const(&self) -> Self {
         let v = self.v;
-        #[allow(clippy::redundant_match)]
         let m_det = match self.determinant() {
             None => 0f32,
             Some(v) => v,

--- a/src/trc.rs
+++ b/src/trc.rs
@@ -93,6 +93,7 @@ pub(crate) fn build_trc_table(num_entries: i32, eotf: impl Fn(f64) -> f64) -> Ve
     table
 }
 
+/// Creates Tone Reproduction curve from gamma
 pub fn curve_from_gamma(gamma: f32) -> ToneReprCurve {
     ToneReprCurve::Lut(vec![gamma.to_u8_fixed8()])
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -246,7 +246,7 @@ fn write_cicp_entry(into: &mut Vec<u8>, cicp: &CicpProfile) {
     let cicp_tag: u32 = TagTypeDefinition::Cicp.into();
     write_u32_be(into, cicp_tag);
     write_u32_be(into, 0);
-    into.push(cicp.color_primaries.into());
+    into.push(cicp.color_primaries as u8);
     into.push(cicp.transfer_characteristics as u8);
     into.push(cicp.matrix_coefficients as u8);
     into.push(if cicp.full_range { 1 } else { 0 });

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -28,7 +28,7 @@
  */
 use crate::profile::{LutDataType, ProfileHeader};
 use crate::tag::{TAG_SIZE, Tag, TagTypeDefinition};
-use crate::trc::Trc;
+use crate::trc::ToneReprCurve;
 use crate::{
     CicpProfile, CmsError, ColorDateTime, ColorProfile, LocalizableString, LutMCurvesType, LutType,
     LutWarehouse, Matrix3f, ProfileSignature, ProfileText, ProfileVersion, Vector3f, Xyz,
@@ -199,9 +199,9 @@ fn write_tag_entry(into: &mut Vec<u8>, tag: Tag, tag_entry: usize, tag_size: usi
     write_u32_be(into, tag_size as u32);
 }
 
-fn write_trc_entry(into: &mut Vec<u8>, trc: &Trc) -> Result<usize, CmsError> {
+fn write_trc_entry(into: &mut Vec<u8>, trc: &ToneReprCurve) -> Result<usize, CmsError> {
     match trc {
-        Trc::Lut(lut) => {
+        ToneReprCurve::Lut(lut) => {
             let curv: u32 = TagTypeDefinition::LutToneCurve.into();
             write_u32_be(into, curv);
             write_u32_be(into, 0);
@@ -211,7 +211,7 @@ fn write_trc_entry(into: &mut Vec<u8>, trc: &Trc) -> Result<usize, CmsError> {
             }
             Ok(12 + lut.len() * 2)
         }
-        Trc::Parametric(parametric_curve) => {
+        ToneReprCurve::Parametric(parametric_curve) => {
             if parametric_curve.len() > 7
                 || parametric_curve.len() == 6
                 || parametric_curve.len() == 2
@@ -246,7 +246,7 @@ fn write_cicp_entry(into: &mut Vec<u8>, cicp: &CicpProfile) {
     let cicp_tag: u32 = TagTypeDefinition::Cicp.into();
     write_u32_be(into, cicp_tag);
     write_u32_be(into, 0);
-    into.push(cicp.color_primaries as u8);
+    into.push(cicp.color_primaries.into());
     into.push(cicp.transfer_characteristics as u8);
     into.push(cicp.matrix_coefficients as u8);
     into.push(if cicp.full_range { 1 } else { 0 });


### PR DESCRIPTION
* `ChromacityTriple` was renamed to `ColorPrimaries` (and the original `ColorPrimaries` `enum` was removed).
* `ColorPrimaries` has a bunch of `const`s that map to the values of the previous `enum`.

* `update_rgb_colorimetry_from_cicp()` was removed (I believe it's no longer needed?) -- the related `ColorPrimaries::has_chromacity` & `white_point()` were also removed.

* Renamed `Trc` to `ToneReprCurve`.

* Various `const`-related changes.

It's still not at a stage were the `new_` ... functions can be turned into `impl` `const`s instead but it's a stepping stone.