### PR TITLE
PoC: safe SIMD

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ "1.85.0", stable ]
+        rust: [ "1.88.0", stable ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ "1.88.0", stable ]
+        rust: [ "1.90.0", stable ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ "1.90.0", stable ]
+        rust: [ "1.88.0", stable ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["multimedia::images"]
 homepage = "https://github.com/awxkee/moxcms"
 repository = "https://github.com/awxkee/moxcms.git"
 exclude = ["*.jpg", "../../assets/*", "*.png", "*.icc", "./assets/*"]
-rust-version = "1.88.0"
+rust-version = "1.90.0"
 
 [dependencies]
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["multimedia::images"]
 homepage = "https://github.com/awxkee/moxcms"
 repository = "https://github.com/awxkee/moxcms.git"
 exclude = ["*.jpg", "../../assets/*", "*.png", "*.icc", "./assets/*"]
-rust-version = "1.90.0"
+rust-version = "1.88.0"
 
 [dependencies]
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["multimedia::images"]
 homepage = "https://github.com/awxkee/moxcms"
 repository = "https://github.com/awxkee/moxcms.git"
 exclude = ["*.jpg", "../../assets/*", "*.png", "*.icc", "./assets/*"]
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 
 [dependencies]
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.88.0"
 [dependencies]
 num-traits = "0.2"
 pxfm = "^0.1.1"
+safe_unaligned_simd = "0.2.3"
 
 [dev-dependencies]
 rand = "0.9"

--- a/src/conversions/avx/interpolator.rs
+++ b/src/conversions/avx/interpolator.rs
@@ -277,7 +277,7 @@ impl<const GRID_SIZE: usize> Fetcher<AvxVectorSse> for TetrahedralAvxSseFetchVec
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,
@@ -464,7 +464,7 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for TrilinearAvxFmaDouble<
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,
@@ -551,7 +551,7 @@ impl<const GRID_SIZE: usize> PyramidalAvxFma<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,
@@ -626,7 +626,7 @@ impl<const GRID_SIZE: usize> PrismaticAvxFma<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,
@@ -729,7 +729,7 @@ impl<const GRID_SIZE: usize> PrismaticAvxFmaDouble<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,
@@ -851,7 +851,7 @@ impl<const GRID_SIZE: usize> PyramidAvxFmaDouble<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,
@@ -925,7 +925,7 @@ impl<const GRID_SIZE: usize> TetrahedralAvxFmaDouble<GRID_SIZE> {
 }
 
 impl<const GRID_SIZE: usize> TrilinearAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,
@@ -982,7 +982,7 @@ impl<const GRID_SIZE: usize> TrilinearAvxFmaDouble<GRID_SIZE> {
 }
 
 impl<const GRID_SIZE: usize> TrilinearAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate(
         &self,
         in_r: usize,

--- a/src/conversions/avx/lut4_to_3.rs
+++ b/src/conversions/avx/lut4_to_3.rs
@@ -74,7 +74,7 @@ where
     (): LutBarycentricReduction<T, U>,
 {
     #[allow(unused_unsafe)]
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn transform_chunk(
         &self,
         src: &[T],

--- a/src/conversions/avx/lut4_to_3.rs
+++ b/src/conversions/avx/lut4_to_3.rs
@@ -122,32 +122,28 @@ where
             let (a0, b0) = (v.0.v, v.1.v);
 
             if T::FINITE {
-                {
-                    let t0 = _mm_set1_ps(t);
-                    let hp = _mm_fnmadd_ps(a0, t0, a0);
-                    let mut v = _mm_fmadd_ps(b0, t0, hp);
-                    v = _mm_max_ps(v, _mm_setzero_ps());
-                    v = _mm_mul_ps(v, value_scale);
-                    v = _mm_min_ps(v, value_scale);
-                    let jvz = _mm_cvtps_epi32(v);
+                let t0 = _mm_set1_ps(t);
+                let hp = _mm_fnmadd_ps(a0, t0, a0);
+                let mut v = _mm_fmadd_ps(b0, t0, hp);
+                v = _mm_max_ps(v, _mm_setzero_ps());
+                v = _mm_mul_ps(v, value_scale);
+                v = _mm_min_ps(v, value_scale);
+                let jvz = _mm_cvtps_epi32(v);
 
-                    let x = _mm_extract_epi32::<0>(jvz);
-                    let y = _mm_extract_epi32::<1>(jvz);
-                    let z = _mm_extract_epi32::<2>(jvz);
+                let x = _mm_extract_epi32::<0>(jvz);
+                let y = _mm_extract_epi32::<1>(jvz);
+                let z = _mm_extract_epi32::<2>(jvz);
 
-                    dst[cn.r_i()] = (x as u32).as_();
-                    dst[cn.g_i()] = (y as u32).as_();
-                    dst[cn.b_i()] = (z as u32).as_();
-                }
+                dst[cn.r_i()] = (x as u32).as_();
+                dst[cn.g_i()] = (y as u32).as_();
+                dst[cn.b_i()] = (z as u32).as_();
             } else {
-                {
-                    let t0 = _mm_set1_ps(t);
-                    let hp = _mm_fnmadd_ps(a0, t0, a0);
-                    let v = _mm_fmadd_ps(b0, t0, hp);
-                    dst[cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(v) as u32).as_();
-                    dst[cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(v) as u32).as_();
-                    dst[cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(v) as u32).as_();
-                }
+                let t0 = _mm_set1_ps(t);
+                let hp = _mm_fnmadd_ps(a0, t0, a0);
+                let v = _mm_fmadd_ps(b0, t0, hp);
+                dst[cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(v) as u32).as_();
+                dst[cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(v) as u32).as_();
+                dst[cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(v) as u32).as_();
             }
             if channels == 4 {
                 dst[cn.a_i()] = max_value;

--- a/src/conversions/avx/lut4_to_3.rs
+++ b/src/conversions/avx/lut4_to_3.rs
@@ -73,9 +73,8 @@ where
     u32: AsPrimitive<T>,
     (): LutBarycentricReduction<T, U>,
 {
-    #[allow(unused_unsafe)]
     #[target_feature(enable = "avx2,fma")]
-    unsafe fn transform_chunk(
+    fn transform_chunk(
         &self,
         src: &[T],
         dst: &mut [T],
@@ -86,7 +85,7 @@ where
         let grid_size = GRID_SIZE as i32;
         let grid_size3 = grid_size * grid_size * grid_size;
 
-        let value_scale = unsafe { _mm_set1_ps(((1 << BIT_DEPTH) - 1) as f32) };
+        let value_scale = _mm_set1_ps(((1 << BIT_DEPTH) - 1) as f32);
         let max_value = ((1 << BIT_DEPTH) - 1u32).as_();
 
         for (src, dst) in src.chunks_exact(4).zip(dst.chunks_exact_mut(channels)) {
@@ -123,7 +122,7 @@ where
             let (a0, b0) = (v.0.v, v.1.v);
 
             if T::FINITE {
-                unsafe {
+                {
                     let t0 = _mm_set1_ps(t);
                     let hp = _mm_fnmadd_ps(a0, t0, a0);
                     let mut v = _mm_fmadd_ps(b0, t0, hp);
@@ -141,7 +140,7 @@ where
                     dst[cn.b_i()] = (z as u32).as_();
                 }
             } else {
-                unsafe {
+                {
                     let t0 = _mm_set1_ps(t);
                     let hp = _mm_fnmadd_ps(a0, t0, a0);
                     let v = _mm_fmadd_ps(b0, t0, hp);

--- a/src/conversions/avx/lut4_to_3_q0_15.rs
+++ b/src/conversions/avx/lut4_to_3_q0_15.rs
@@ -67,15 +67,13 @@ where
     u32: AsPrimitive<T>,
     (): LutBarycentricReduction<T, U>,
 {
-    #[allow(unused_unsafe)]
     #[target_feature(enable = "avx2")]
-    unsafe fn transform_chunk(
+    fn transform_chunk(
         &self,
         src: &[T],
         dst: &mut [T],
         interpolator: Box<dyn AvxMdInterpolationQ0_15Double + Send + Sync>,
     ) {
-        unsafe {
             let cn = Layout::from(LAYOUT);
             let channels = cn.channels();
             let grid_size = GRID_SIZE as i32;
@@ -148,7 +146,6 @@ where
                     dst[cn.a_i()] = max_value;
                 }
             }
-        }
     }
 }
 

--- a/src/conversions/avx/lut4_to_3_q0_15.rs
+++ b/src/conversions/avx/lut4_to_3_q0_15.rs
@@ -74,78 +74,78 @@ where
         dst: &mut [T],
         interpolator: Box<dyn AvxMdInterpolationQ0_15Double + Send + Sync>,
     ) {
-            let cn = Layout::from(LAYOUT);
-            let channels = cn.channels();
-            let grid_size = GRID_SIZE as i32;
-            let grid_size3 = grid_size * grid_size * grid_size;
+        let cn = Layout::from(LAYOUT);
+        let channels = cn.channels();
+        let grid_size = GRID_SIZE as i32;
+        let grid_size3 = grid_size * grid_size * grid_size;
 
-            let f_value_scale = _mm_set1_ps(1. / ((1 << 14i32) - 1) as f32);
-            let max_value = ((1u32 << BIT_DEPTH) - 1).as_();
-            let v_max_scale = if T::FINITE {
-                _mm_set1_epi16(((1i32 << BIT_DEPTH) - 1) as i16)
+        let f_value_scale = _mm_set1_ps(1. / ((1 << 14i32) - 1) as f32);
+        let max_value = ((1u32 << BIT_DEPTH) - 1).as_();
+        let v_max_scale = if T::FINITE {
+            _mm_set1_epi16(((1i32 << BIT_DEPTH) - 1) as i16)
+        } else {
+            _mm_set1_epi16(((1i32 << 14i32) - 1) as i16)
+        };
+
+        for (src, dst) in src.chunks_exact(4).zip(dst.chunks_exact_mut(channels)) {
+            let c = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
+                src[0],
+            );
+            let m = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
+                src[1],
+            );
+            let y = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
+                src[2],
+            );
+            let k = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
+                src[3],
+            );
+
+            let k_weights = self.weights[k.as_()];
+
+            let w: i32 = k_weights.x;
+            let w_n: i32 = k_weights.x_n;
+            const Q: i16 = ((1i32 << 15) - 1) as i16;
+            let t: i16 = k_weights.w;
+            let t_n: i16 = Q - t;
+
+            let table1 = &self.lut[(w * grid_size3) as usize..];
+            let table2 = &self.lut[(w_n * grid_size3) as usize..];
+
+            let v = interpolator.inter3_sse(
+                table1,
+                table2,
+                c.as_(),
+                m.as_(),
+                y.as_(),
+                self.weights.as_slice(),
+            );
+            let (a0, b0) = (v.0.v, v.1.v);
+
+            let hp = _mm_mulhrs_epi16(_mm_set1_epi16(t_n), a0);
+            let v = _mm_add_epi16(hp, _mm_mulhrs_epi16(b0, _mm_set1_epi16(t)));
+
+            if T::FINITE {
+                let mut o = _mm_max_epi16(v, _mm_setzero_si128());
+                o = _mm_min_epi16(o, v_max_scale);
+                let x = _mm_extract_epi16::<0>(o);
+                let y = _mm_extract_epi16::<1>(o);
+                let z = _mm_extract_epi16::<2>(o);
+
+                dst[cn.r_i()] = (x as u32).as_();
+                dst[cn.g_i()] = (y as u32).as_();
+                dst[cn.b_i()] = (z as u32).as_();
             } else {
-                _mm_set1_epi16(((1i32 << 14i32) - 1) as i16)
-            };
-
-            for (src, dst) in src.chunks_exact(4).zip(dst.chunks_exact_mut(channels)) {
-                let c = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
-                    src[0],
-                );
-                let m = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
-                    src[1],
-                );
-                let y = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
-                    src[2],
-                );
-                let k = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
-                    src[3],
-                );
-
-                let k_weights = self.weights[k.as_()];
-
-                let w: i32 = k_weights.x;
-                let w_n: i32 = k_weights.x_n;
-                const Q: i16 = ((1i32 << 15) - 1) as i16;
-                let t: i16 = k_weights.w;
-                let t_n: i16 = Q - t;
-
-                let table1 = &self.lut[(w * grid_size3) as usize..];
-                let table2 = &self.lut[(w_n * grid_size3) as usize..];
-
-                let v = interpolator.inter3_sse(
-                    table1,
-                    table2,
-                    c.as_(),
-                    m.as_(),
-                    y.as_(),
-                    self.weights.as_slice(),
-                );
-                let (a0, b0) = (v.0.v, v.1.v);
-
-                let hp = _mm_mulhrs_epi16(_mm_set1_epi16(t_n), a0);
-                let v = _mm_add_epi16(hp, _mm_mulhrs_epi16(b0, _mm_set1_epi16(t)));
-
-                if T::FINITE {
-                    let mut o = _mm_max_epi16(v, _mm_setzero_si128());
-                    o = _mm_min_epi16(o, v_max_scale);
-                    let x = _mm_extract_epi16::<0>(o);
-                    let y = _mm_extract_epi16::<1>(o);
-                    let z = _mm_extract_epi16::<2>(o);
-
-                    dst[cn.r_i()] = (x as u32).as_();
-                    dst[cn.g_i()] = (y as u32).as_();
-                    dst[cn.b_i()] = (z as u32).as_();
-                } else {
-                    let mut r = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(v));
-                    r = _mm_mul_ps(r, f_value_scale);
-                    dst[cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(r) as u32).as_();
-                    dst[cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(r) as u32).as_();
-                    dst[cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(r) as u32).as_();
-                }
-                if channels == 4 {
-                    dst[cn.a_i()] = max_value;
-                }
+                let mut r = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(v));
+                r = _mm_mul_ps(r, f_value_scale);
+                dst[cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(r) as u32).as_();
+                dst[cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(r) as u32).as_();
+                dst[cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(r) as u32).as_();
             }
+            if channels == 4 {
+                dst[cn.a_i()] = max_value;
+            }
+        }
     }
 }
 

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -59,11 +59,7 @@ where
     u32: AsPrimitive<T>,
 {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn transform_impl<const FMA: bool>(
-        &self,
-        src: &[T],
-        dst: &mut [T],
-    ) -> Result<(), CmsError> {
+    fn transform_impl<const FMA: bool>(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         let src_cn = Layout::from(SRC_LAYOUT);
         let dst_cn = Layout::from(DST_LAYOUT);
         let src_channels = src_cn.channels();

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -31,6 +31,7 @@ use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
 use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
+use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
 use std::arch::x86_64::*;
 
 #[repr(align(32), C)]

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -30,8 +30,8 @@ use crate::conversions::TransformMatrixShaper;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 #[repr(align(32), C)]

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -274,7 +274,7 @@ where
             v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
 
             let zx = _mm_cvtps_epi32(v);
-            let temporary_first_half: &mut [u16; 8] = &mut temporary0.0[..8].try_into().unwrap();
+            let temporary_first_half: &mut [u16; 8] = (&mut temporary0.0[..8]).try_into().unwrap();
             _mm_storeu_si128(temporary_first_half, zx);
 
             dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -59,7 +59,7 @@ impl<
 where
     u32: AsPrimitive<T>,
 {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     fn transform_impl<const FMA: bool>(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         let src_cn = Layout::from(SRC_LAYOUT);
         let dst_cn = Layout::from(DST_LAYOUT);

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -86,209 +86,206 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        {
-            let m0 = _mm256_setr_ps(
-                t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
+        let m0 = _mm256_setr_ps(
+            t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
+        );
+        let m1 = _mm256_setr_ps(
+            t.v[1][0], t.v[1][1], t.v[1][2], 0., t.v[1][0], t.v[1][1], t.v[1][2], 0.,
+        );
+        let m2 = _mm256_setr_ps(
+            t.v[2][0], t.v[2][1], t.v[2][2], 0., t.v[2][0], t.v[2][1], t.v[2][2], 0.,
+        );
+
+        let zeros = _mm_setzero_ps();
+
+        let v_scale = _mm256_set1_ps(scale);
+
+        let mut src = src;
+        let mut dst = dst;
+
+        let mut src_iter = src.chunks_exact(src_channels * 2);
+        let dst_iter = dst.chunks_exact_mut(dst_channels * 2);
+
+        let (mut r0, mut g0, mut b0, mut a0);
+        let (mut r1, mut g1, mut b1, mut a1);
+
+        if let Some(src) = src_iter.next() {
+            r0 = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
+            g0 = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
+            b0 = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
+            r1 = _mm_broadcast_ss(
+                &self.profile.r_linear[src[src_cn.r_i() + src_channels]._as_usize()],
             );
-            let m1 = _mm256_setr_ps(
-                t.v[1][0], t.v[1][1], t.v[1][2], 0., t.v[1][0], t.v[1][1], t.v[1][2], 0.,
+            g1 = _mm_broadcast_ss(
+                &self.profile.g_linear[src[src_cn.g_i() + src_channels]._as_usize()],
             );
-            let m2 = _mm256_setr_ps(
-                t.v[2][0], t.v[2][1], t.v[2][2], 0., t.v[2][0], t.v[2][1], t.v[2][2], 0.,
+            b1 = _mm_broadcast_ss(
+                &self.profile.b_linear[src[src_cn.b_i() + src_channels]._as_usize()],
             );
-
-            let zeros = _mm_setzero_ps();
-
-            let v_scale = _mm256_set1_ps(scale);
-
-            let mut src = src;
-            let mut dst = dst;
-
-            let mut src_iter = src.chunks_exact(src_channels * 2);
-            let dst_iter = dst.chunks_exact_mut(dst_channels * 2);
-
-            let (mut r0, mut g0, mut b0, mut a0);
-            let (mut r1, mut g1, mut b1, mut a1);
-
-            if let Some(src) = src_iter.next() {
-                r0 = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
-                g0 = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
-                b0 = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
-                r1 = _mm_broadcast_ss(
-                    &self.profile.r_linear[src[src_cn.r_i() + src_channels]._as_usize()],
-                );
-                g1 = _mm_broadcast_ss(
-                    &self.profile.g_linear[src[src_cn.g_i() + src_channels]._as_usize()],
-                );
-                b1 = _mm_broadcast_ss(
-                    &self.profile.b_linear[src[src_cn.b_i() + src_channels]._as_usize()],
-                );
-                a0 = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-                a1 = if src_channels == 4 {
-                    src[src_cn.a_i() + src_channels]
-                } else {
-                    max_colors
-                };
+            a0 = if src_channels == 4 {
+                src[src_cn.a_i()]
             } else {
-                r0 = _mm_setzero_ps();
-                g0 = _mm_setzero_ps();
-                b0 = _mm_setzero_ps();
-                a0 = max_colors;
-                r1 = _mm_setzero_ps();
-                g1 = _mm_setzero_ps();
-                b1 = _mm_setzero_ps();
-                a1 = max_colors;
+                max_colors
+            };
+            a1 = if src_channels == 4 {
+                src[src_cn.a_i() + src_channels]
+            } else {
+                max_colors
+            };
+        } else {
+            r0 = _mm_setzero_ps();
+            g0 = _mm_setzero_ps();
+            b0 = _mm_setzero_ps();
+            a0 = max_colors;
+            r1 = _mm_setzero_ps();
+            g1 = _mm_setzero_ps();
+            b1 = _mm_setzero_ps();
+            a1 = max_colors;
+        }
+
+        for (src, dst) in src_iter.zip(dst_iter) {
+            let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
+            let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
+            let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
+
+            let mut v = if FMA {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_fmadd_ps(g, m1, v0);
+                _mm256_fmadd_ps(b, m2, v1)
+            } else {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_mul_ps(g, m1);
+                let v2 = _mm256_mul_ps(b, m2);
+
+                _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
+            };
+
+            v = _mm256_max_ps(v, _mm256_setzero_ps());
+            v = _mm256_mul_ps(v, v_scale);
+            v = _mm256_min_ps(v, v_scale);
+
+            let zx = _mm256_cvtps_epi32(v);
+            _mm256_storeu_si256(&mut temporary0.0, zx);
+
+            r0 = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
+            g0 = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
+            b0 = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
+            r1 = _mm_broadcast_ss(
+                &self.profile.r_linear[src[src_cn.r_i() + src_channels]._as_usize()],
+            );
+            g1 = _mm_broadcast_ss(
+                &self.profile.g_linear[src[src_cn.g_i() + src_channels]._as_usize()],
+            );
+            b1 = _mm_broadcast_ss(
+                &self.profile.b_linear[src[src_cn.b_i() + src_channels]._as_usize()],
+            );
+
+            dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a0;
             }
 
-            for (src, dst) in src_iter.zip(dst_iter) {
-                let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
-                let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
-                let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
-
-                let mut v = if FMA {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_fmadd_ps(g, m1, v0);
-                    _mm256_fmadd_ps(b, m2, v1)
-                } else {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_mul_ps(g, m1);
-                    let v2 = _mm256_mul_ps(b, m2);
-
-                    _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
-                };
-
-                v = _mm256_max_ps(v, _mm256_setzero_ps());
-                v = _mm256_mul_ps(v, v_scale);
-                v = _mm256_min_ps(v, v_scale);
-
-                let zx = _mm256_cvtps_epi32(v);
-                _mm256_storeu_si256(&mut temporary0.0, zx);
-
-                r0 = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
-                g0 = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
-                b0 = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
-                r1 = _mm_broadcast_ss(
-                    &self.profile.r_linear[src[src_cn.r_i() + src_channels]._as_usize()],
-                );
-                g1 = _mm_broadcast_ss(
-                    &self.profile.g_linear[src[src_cn.g_i() + src_channels]._as_usize()],
-                );
-                b1 = _mm_broadcast_ss(
-                    &self.profile.b_linear[src[src_cn.b_i() + src_channels]._as_usize()],
-                );
-
-                dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a0;
-                }
-
-                dst[dst_cn.r_i() + dst_channels] = self.profile.r_gamma[temporary0.0[8] as usize];
-                dst[dst_cn.g_i() + dst_channels] = self.profile.g_gamma[temporary0.0[10] as usize];
-                dst[dst_cn.b_i() + dst_channels] = self.profile.b_gamma[temporary0.0[12] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i() + dst_channels] = a1;
-                }
-
-                a0 = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-                a1 = if src_channels == 4 {
-                    src[src_cn.a_i() + src_channels]
-                } else {
-                    max_colors
-                };
+            dst[dst_cn.r_i() + dst_channels] = self.profile.r_gamma[temporary0.0[8] as usize];
+            dst[dst_cn.g_i() + dst_channels] = self.profile.g_gamma[temporary0.0[10] as usize];
+            dst[dst_cn.b_i() + dst_channels] = self.profile.b_gamma[temporary0.0[12] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i() + dst_channels] = a1;
             }
 
-            if let Some(dst) = dst.chunks_exact_mut(dst_channels * 2).last() {
-                let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
-                let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
-                let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
+            a0 = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+            a1 = if src_channels == 4 {
+                src[src_cn.a_i() + src_channels]
+            } else {
+                max_colors
+            };
+        }
 
-                let mut v = if FMA {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_fmadd_ps(g, m1, v0);
-                    _mm256_fmadd_ps(b, m2, v1)
-                } else {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_mul_ps(g, m1);
-                    let v2 = _mm256_mul_ps(b, m2);
+        if let Some(dst) = dst.chunks_exact_mut(dst_channels * 2).last() {
+            let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
+            let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
+            let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
 
-                    _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
-                };
+            let mut v = if FMA {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_fmadd_ps(g, m1, v0);
+                _mm256_fmadd_ps(b, m2, v1)
+            } else {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_mul_ps(g, m1);
+                let v2 = _mm256_mul_ps(b, m2);
 
-                v = _mm256_max_ps(v, _mm256_setzero_ps());
-                v = _mm256_mul_ps(v, v_scale);
-                v = _mm256_min_ps(v, v_scale);
+                _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
+            };
 
-                let zx = _mm256_cvtps_epi32(v);
-                _mm256_storeu_si256(&mut temporary0.0, zx);
+            v = _mm256_max_ps(v, _mm256_setzero_ps());
+            v = _mm256_mul_ps(v, v_scale);
+            v = _mm256_min_ps(v, v_scale);
 
-                dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a0;
-                }
+            let zx = _mm256_cvtps_epi32(v);
+            _mm256_storeu_si256(&mut temporary0.0, zx);
 
-                dst[dst_cn.r_i() + dst_channels] = self.profile.r_gamma[temporary0.0[8] as usize];
-                dst[dst_cn.g_i() + dst_channels] = self.profile.g_gamma[temporary0.0[10] as usize];
-                dst[dst_cn.b_i() + dst_channels] = self.profile.b_gamma[temporary0.0[12] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i() + dst_channels] = a1;
-                }
+            dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a0;
             }
 
-            src = src.chunks_exact(src_channels * 2).remainder();
-            dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
+            dst[dst_cn.r_i() + dst_channels] = self.profile.r_gamma[temporary0.0[8] as usize];
+            dst[dst_cn.g_i() + dst_channels] = self.profile.g_gamma[temporary0.0[10] as usize];
+            dst[dst_cn.b_i() + dst_channels] = self.profile.b_gamma[temporary0.0[12] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i() + dst_channels] = a1;
+            }
+        }
 
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let r = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
-                let g = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
-                let b = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
+        src = src.chunks_exact(src_channels * 2).remainder();
+        dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
 
-                let mut v = if FMA {
-                    let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
-                    let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
-                    _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1)
-                } else {
-                    let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
-                    let v1 = _mm_mul_ps(g, _mm256_castps256_ps128(m1));
-                    let v2 = _mm_mul_ps(b, _mm256_castps256_ps128(m2));
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let r = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
+            let g = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
+            let b = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
 
-                    _mm_add_ps(_mm_add_ps(v0, v1), v2)
-                };
+            let mut v = if FMA {
+                let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
+                let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
+                _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1)
+            } else {
+                let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
+                let v1 = _mm_mul_ps(g, _mm256_castps256_ps128(m1));
+                let v2 = _mm_mul_ps(b, _mm256_castps256_ps128(m2));
 
-                v = _mm_max_ps(v, zeros);
-                v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
-                v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
+                _mm_add_ps(_mm_add_ps(v0, v1), v2)
+            };
 
-                let zx = _mm_cvtps_epi32(v);
-                let temporary_first_half: &mut [u16; 8] =
-                    &mut temporary0.0[..8].try_into().unwrap();
-                _mm_storeu_si128(temporary_first_half, zx);
+            v = _mm_max_ps(v, zeros);
+            v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
+            v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
 
-                dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+            let zx = _mm_cvtps_epi32(v);
+            let temporary_first_half: &mut [u16; 8] = &mut temporary0.0[..8].try_into().unwrap();
+            _mm_storeu_si128(temporary_first_half, zx);
+
+            dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
             }
         }
 

--- a/src/conversions/avx/rgb_xyz_opt.rs
+++ b/src/conversions/avx/rgb_xyz_opt.rs
@@ -51,7 +51,7 @@ impl<
 where
     u32: AsPrimitive<T>,
 {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn transform_impl<const FMA: bool>(
         &self,
         src: &[T],

--- a/src/conversions/avx/rgb_xyz_q2_13.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13.rs
@@ -31,8 +31,8 @@ use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFp;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbQ2_13Avx<

--- a/src/conversions/avx/rgb_xyz_q2_13.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13.rs
@@ -44,10 +44,14 @@ pub(crate) struct TransformShaperRgbQ2_13Avx<
     pub(crate) gamma_lut: usize,
 }
 
-#[inline(always)]
-pub(crate) unsafe fn _xmm_broadcast_epi32(f: &i32) -> __m128i {
-    let float_ref: &f32 = unsafe { &*(f as *const i32 as *const f32) };
-    unsafe { _mm_castps_si128(_mm_broadcast_ss(float_ref)) }
+#[inline]
+#[target_feature(enable = "avx2")]
+pub(crate) fn _xmm_broadcast_epi32(f: &i32) -> __m128i {
+    // safe transmute would require `bytemuck` dependency,
+    // but this optimizes into the same code as a transmute:
+    // https://rust.godbolt.org/z/Pfqb7YG7c
+    let float_ref = f32::from_ne_bytes(f.to_ne_bytes());
+    _mm_castps_si128(_mm_broadcast_ss(&float_ref))
 }
 
 impl<

--- a/src/conversions/avx/rgb_xyz_q2_13.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13.rs
@@ -31,6 +31,7 @@ use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFp;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbQ2_13Avx<
@@ -180,7 +181,7 @@ where
                 v0 = _mm256_max_epi32(v0, zeros);
                 v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+                _mm256_storeu_si256(&mut temporary0.0, v0);
 
                 r0 = _xmm_broadcast_epi32(r_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
                 g0 = _xmm_broadcast_epi32(g_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
@@ -239,7 +240,7 @@ where
                 v0 = _mm256_max_epi32(v0, zeros);
                 v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+                _mm256_storeu_si256(&mut temporary0.0, v0);
 
                 dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
@@ -288,7 +289,9 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
 
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, v);
+                let temporary_first_half: &mut [u16; 8] =
+                    (&mut temporary0.0[..8]).try_into().unwrap();
+                _mm_storeu_si128(temporary_first_half, v);
 
                 dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];

--- a/src/conversions/avx/rgb_xyz_q2_13.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13.rs
@@ -32,6 +32,7 @@ use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
 use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
+use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbQ2_13Avx<

--- a/src/conversions/avx/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13_opt.rs
@@ -32,6 +32,7 @@ use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbQ2_13OptAvx<
@@ -55,7 +56,7 @@ where
     u32: AsPrimitive<T>,
 {
     #[target_feature(enable = "avx2")]
-    unsafe fn transform_avx2(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
+    fn transform_avx2(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         let src_cn = Layout::from(SRC_LAYOUT);
         let dst_cn = Layout::from(DST_LAYOUT);
         let src_channels = src_cn.channels();
@@ -163,7 +164,7 @@ where
                 v0 = _mm256_max_epi32(v0, zeros);
                 v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+                _mm256_storeu_si256(&mut temporary0.0, v0);
 
                 r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
                 g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
@@ -223,7 +224,7 @@ where
                 v0 = _mm256_max_epi32(v0, zeros);
                 v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+                _mm256_storeu_si256(&mut temporary0.0, v0);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -272,7 +273,9 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
 
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, v);
+                let temporary_first_half: &mut [u16; 8] =
+                    (&mut temporary0.0[..8]).try_into().unwrap();
+                _mm_storeu_si128(temporary_first_half, v);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];

--- a/src/conversions/avx/t_lut3_to_3.rs
+++ b/src/conversions/avx/t_lut3_to_3.rs
@@ -76,7 +76,7 @@ where
     (): LutBarycentricReduction<T, U>,
 {
     #[allow(unused_unsafe)]
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn transform_chunk(
         &self,
         src: &[T],

--- a/src/conversions/avx/t_lut3_to_3.rs
+++ b/src/conversions/avx/t_lut3_to_3.rs
@@ -75,9 +75,8 @@ where
     u32: AsPrimitive<T>,
     (): LutBarycentricReduction<T, U>,
 {
-    #[allow(unused_unsafe)]
     #[target_feature(enable = "avx2,fma")]
-    unsafe fn transform_chunk(
+    fn transform_chunk(
         &self,
         src: &[T],
         dst: &mut [T],
@@ -89,7 +88,7 @@ where
         let dst_cn = Layout::from(DST_LAYOUT);
         let dst_channels = dst_cn.channels();
 
-        let value_scale = unsafe { _mm_set1_ps(((1 << BIT_DEPTH) - 1) as f32) };
+        let value_scale = _mm_set1_ps(((1 << BIT_DEPTH) - 1) as f32);
         let max_value = ((1u32 << BIT_DEPTH) - 1).as_();
 
         for (src, dst) in src
@@ -120,7 +119,6 @@ where
                 self.weights.as_slice(),
             );
             if T::FINITE {
-                unsafe {
                     let mut r = _mm_mul_ps(v.v, value_scale);
                     r = _mm_max_ps(r, _mm_setzero_ps());
                     r = _mm_min_ps(r, value_scale);
@@ -133,13 +131,10 @@ where
                     dst[dst_cn.r_i()] = (x as u32).as_();
                     dst[dst_cn.g_i()] = (y as u32).as_();
                     dst[dst_cn.b_i()] = (z as u32).as_();
-                }
             } else {
-                unsafe {
                     dst[dst_cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(v.v) as u32).as_();
                     dst[dst_cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(v.v) as u32).as_();
                     dst[dst_cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(v.v) as u32).as_();
-                }
             }
             if dst_channels == 4 {
                 dst[dst_cn.a_i()] = a;

--- a/src/conversions/avx/t_lut3_to_3.rs
+++ b/src/conversions/avx/t_lut3_to_3.rs
@@ -119,22 +119,22 @@ where
                 self.weights.as_slice(),
             );
             if T::FINITE {
-                    let mut r = _mm_mul_ps(v.v, value_scale);
-                    r = _mm_max_ps(r, _mm_setzero_ps());
-                    r = _mm_min_ps(r, value_scale);
-                    let jvz = _mm_cvtps_epi32(r);
+                let mut r = _mm_mul_ps(v.v, value_scale);
+                r = _mm_max_ps(r, _mm_setzero_ps());
+                r = _mm_min_ps(r, value_scale);
+                let jvz = _mm_cvtps_epi32(r);
 
-                    let x = _mm_extract_epi32::<0>(jvz);
-                    let y = _mm_extract_epi32::<1>(jvz);
-                    let z = _mm_extract_epi32::<2>(jvz);
+                let x = _mm_extract_epi32::<0>(jvz);
+                let y = _mm_extract_epi32::<1>(jvz);
+                let z = _mm_extract_epi32::<2>(jvz);
 
-                    dst[dst_cn.r_i()] = (x as u32).as_();
-                    dst[dst_cn.g_i()] = (y as u32).as_();
-                    dst[dst_cn.b_i()] = (z as u32).as_();
+                dst[dst_cn.r_i()] = (x as u32).as_();
+                dst[dst_cn.g_i()] = (y as u32).as_();
+                dst[dst_cn.b_i()] = (z as u32).as_();
             } else {
-                    dst[dst_cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(v.v) as u32).as_();
-                    dst[dst_cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(v.v) as u32).as_();
-                    dst[dst_cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(v.v) as u32).as_();
+                dst[dst_cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(v.v) as u32).as_();
+                dst[dst_cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(v.v) as u32).as_();
+                dst[dst_cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(v.v) as u32).as_();
             }
             if dst_channels == 4 {
                 dst[dst_cn.a_i()] = a;

--- a/src/conversions/avx/t_lut3_to_3_q0_15.rs
+++ b/src/conversions/avx/t_lut3_to_3_q0_15.rs
@@ -79,15 +79,13 @@ where
     u32: AsPrimitive<T>,
     (): LutBarycentricReduction<T, U>,
 {
-    #[allow(unused_unsafe)]
     #[target_feature(enable = "avx2")]
-    unsafe fn transform_chunk(
+    fn transform_chunk(
         &self,
         src: &[T],
         dst: &mut [T],
         interpolator: Box<dyn AvxMdInterpolationQ0_15 + Send + Sync>,
     ) {
-        unsafe {
             let src_cn = Layout::from(SRC_LAYOUT);
             let src_channels = src_cn.channels();
 
@@ -150,7 +148,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
     }
 }
 

--- a/src/conversions/avx/t_lut3_to_3_q0_15.rs
+++ b/src/conversions/avx/t_lut3_to_3_q0_15.rs
@@ -86,68 +86,68 @@ where
         dst: &mut [T],
         interpolator: Box<dyn AvxMdInterpolationQ0_15 + Send + Sync>,
     ) {
-            let src_cn = Layout::from(SRC_LAYOUT);
-            let src_channels = src_cn.channels();
+        let src_cn = Layout::from(SRC_LAYOUT);
+        let src_channels = src_cn.channels();
 
-            let dst_cn = Layout::from(DST_LAYOUT);
-            let dst_channels = dst_cn.channels();
+        let dst_cn = Layout::from(DST_LAYOUT);
+        let dst_channels = dst_cn.channels();
 
-            let f_value_scale = _mm_set1_ps(1. / ((1 << 14i32) - 1) as f32);
-            let max_value = ((1u32 << BIT_DEPTH) - 1).as_();
-            let v_max_scale = if T::FINITE {
-                _mm_set1_epi16(((1i32 << BIT_DEPTH) - 1) as i16)
+        let f_value_scale = _mm_set1_ps(1. / ((1 << 14i32) - 1) as f32);
+        let max_value = ((1u32 << BIT_DEPTH) - 1).as_();
+        let v_max_scale = if T::FINITE {
+            _mm_set1_epi16(((1i32 << BIT_DEPTH) - 1) as i16)
+        } else {
+            _mm_set1_epi16(((1i32 << 14i32) - 1) as i16)
+        };
+
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let x = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
+                src[src_cn.r_i()],
+            );
+            let y = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
+                src[src_cn.g_i()],
+            );
+            let z = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
+                src[src_cn.b_i()],
+            );
+
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
             } else {
-                _mm_set1_epi16(((1i32 << 14i32) - 1) as i16)
+                max_value
             };
 
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let x = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
-                    src[src_cn.r_i()],
-                );
-                let y = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
-                    src[src_cn.g_i()],
-                );
-                let z = <() as LutBarycentricReduction<T, U>>::reduce::<BIT_DEPTH, BARYCENTRIC_BINS>(
-                    src[src_cn.b_i()],
-                );
+            let v = interpolator.inter3_sse(
+                &self.lut,
+                x.as_(),
+                y.as_(),
+                z.as_(),
+                self.weights.as_slice(),
+            );
+            if T::FINITE {
+                let mut o = _mm_max_epi16(v.v, _mm_setzero_si128());
+                o = _mm_min_epi16(o, v_max_scale);
+                let x = _mm_extract_epi16::<0>(o);
+                let y = _mm_extract_epi16::<1>(o);
+                let z = _mm_extract_epi16::<2>(o);
 
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_value
-                };
-
-                let v = interpolator.inter3_sse(
-                    &self.lut,
-                    x.as_(),
-                    y.as_(),
-                    z.as_(),
-                    self.weights.as_slice(),
-                );
-                if T::FINITE {
-                    let mut o = _mm_max_epi16(v.v, _mm_setzero_si128());
-                    o = _mm_min_epi16(o, v_max_scale);
-                    let x = _mm_extract_epi16::<0>(o);
-                    let y = _mm_extract_epi16::<1>(o);
-                    let z = _mm_extract_epi16::<2>(o);
-
-                    dst[dst_cn.r_i()] = (x as u32).as_();
-                    dst[dst_cn.g_i()] = (y as u32).as_();
-                    dst[dst_cn.b_i()] = (z as u32).as_();
-                } else {
-                    let mut r = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(v.v));
-                    r = _mm_mul_ps(r, f_value_scale);
-                    dst[dst_cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(r) as u32).as_();
-                    dst[dst_cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(r) as u32).as_();
-                    dst[dst_cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(r) as u32).as_();
-                }
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+                dst[dst_cn.r_i()] = (x as u32).as_();
+                dst[dst_cn.g_i()] = (y as u32).as_();
+                dst[dst_cn.b_i()] = (z as u32).as_();
+            } else {
+                let mut r = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(v.v));
+                r = _mm_mul_ps(r, f_value_scale);
+                dst[dst_cn.r_i()] = f32::from_bits(_mm_extract_ps::<0>(r) as u32).as_();
+                dst[dst_cn.g_i()] = f32::from_bits(_mm_extract_ps::<1>(r) as u32).as_();
+                dst[dst_cn.b_i()] = f32::from_bits(_mm_extract_ps::<2>(r) as u32).as_();
             }
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Removes all `unsafe` from `avx/rgb_xyz.rs` as a proof of concept. The only remaining `unsafe` in that file is for calling a function with a `#[target_feature]` annotation.

Starting with Rust 1.87 [platform intrinsics are no longer unsafe to call](https://rust-lang.github.io/rfcs/2396-target-feature-1.1.html). Load/store intrinsics still are because they operate on raw pointers, but the `safe_unaligned_simd` crate provides safe wrappers around those.

This changes aligned store intrinsics into unaligned ones, but the compiler will turn them right back into aligned store instructions if it can tell the address is always aligned, which should apply here.

Dropping the now-unnecessary block created lots of noisy whitespace changes, but that is split into its own commit to ease review.

This is meant as a starting point, I am happy to help convert the rest of the code to this style if you are OK with the basic direction.