### PR TITLE
Fix build of app/; use SIMD intrinsics in benchmarks when available

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 image = {version = "0.25.5", default-features = true}
-moxcms = {path = "../"}
+moxcms = {path = "../", features = ["options"]}
 lcms2 = "6.1.0"
 #jxl-oxide = {path = "../../../RustroverProjects/jxl-oxide/crates/jxl-oxide", features = ["moxcms", "lcms2"]}
 zune-jpeg = "0.5.0-rc2"


### PR DESCRIPTION
Fixes build of the benchmarks, which currently fail to build:

```
error[E0599]: no variant or associated item named `Prism` found for enum `InterpolationMethod` in the current scope
   --> app/benches/lut/main.rs:327:64
    |
327 |                     interpolation_method: InterpolationMethod::Prism,
    |                                                                ^^^^^ variant or associated item not found in `InterpolationMethod`
```

Also makes moxcms use SIMD in benchmarks when it's available.