### PR TITLE
Added in place transforms

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -38,28 +38,54 @@ jobs:
       - run: RUSTFLAGS="-C target-feature=+avx2" cargo build --target x86_64-unknown-linux-gnu --no-default-features --features sse
       - run: RUSTFLAGS="-C target-feature=+avx2" cargo +nightly build --target x86_64-unknown-linux-gnu --no-default-features --features avx,avx512
       - run: RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-unknown-unknown
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features avx_shaper_paths
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features avx_shaper_optimized_paths
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features avx_shaper_fixed_point_paths
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features avx_luts
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features avx_shaper_fixed_point_paths,in_place
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features sse_shaper_paths
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features sse_shaper_optimized_paths
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features sse_shaper_fixed_point_paths
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features sse_luts
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features sse_shaper_fixed_point_paths,in_place
+      - run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features neon_shaper_paths
+      - run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features neon_shaper_optimized_paths
+      - run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features neon_shaper_fixed_point_paths
+      - run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features neon_luts
+      - run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features neon_shaper_fixed_point_paths,in_place
+      - run: cargo build --target x86_64-unknown-linux-gnu --no-default-features --features in_place
+      - run: cargo build --target aarch64-unknown-linux-gnu --no-default-features --features in_place
 
   tests_arm:
     name: Tests
-    strategy:
-      matrix:
-        features: [ "", neon ]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test  --no-default-features --features "${{ matrix.features }}"
+      - run: cargo test --no-default-features
+      - run: cargo test --features neon_shaper_paths
+      - run: cargo test --features neon_shaper_optimized_paths
+      - run: cargo test --features neon_shaper_fixed_point_paths
+      - run: cargo test --features neon_luts
+      - run: cargo test --features neon_shaper_fixed_point_paths,in_place
 
   tests_x86:
     name: Tests
-    strategy:
-      matrix:
-        features: [ "", sse, avx ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --no-default-features --features "${{ matrix.features }}"
+      - run: cargo test --no-default-features
+      - run: cargo test --features avx_shaper_paths
+      - run: cargo test --features avx_shaper_optimized_paths
+      - run: cargo test --features avx_shaper_fixed_point_paths
+      - run: cargo test --features avx_luts
+      - run: cargo test --features avx_shaper_fixed_point_paths,in_place
+      - run: cargo test --features sse_shaper_paths
+      - run: cargo test --features sse_shaper_optimized_paths
+      - run: cargo test --features sse_shaper_fixed_point_paths
+      - run: cargo test --features sse_luts
+      - run: cargo test --features sse_shaper_fixed_point_paths,in_place
 
   clippy_x86:
     name: Clippy x86 Stable
@@ -67,7 +93,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo clippy --features avx,sse,neon,options -- -D warnings
+      - run: cargo clippy --no-default-features                             -- -D warnings
+      - run: cargo clippy --features avx_shaper_paths                       -- -D warnings
+      - run: cargo clippy --features avx_shaper_optimized_paths             -- -D warnings
+      - run: cargo clippy --features avx_shaper_fixed_point_paths           -- -D warnings
+      - run: cargo clippy --features avx_luts                               -- -D warnings
+      - run: cargo clippy --features avx_shaper_fixed_point_paths,in_place  -- -D warnings
+      - run: cargo clippy --features sse_shaper_paths                       -- -D warnings
+      - run: cargo clippy --features sse_shaper_optimized_paths             -- -D warnings
+      - run: cargo clippy --features sse_shaper_fixed_point_paths           -- -D warnings
+      - run: cargo clippy --features sse_luts                               -- -D warnings
+      - run: cargo clippy --features sse_shaper_fixed_point_paths,in_place  -- -D warnings
 
   clippy_x86_nightly:
     name: Clippy x86 Nightly
@@ -76,7 +112,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - run: rustup component add clippy
-      - run: cargo clippy --all-features -- -D warnings
+      - run: cargo clippy  --no-default-features                            -- -D warnings
+      - run: cargo clippy  --features avx_shaper_paths                      -- -D warnings
+      - run: cargo clippy  --features avx_shaper_optimized_paths            -- -D warnings
+      - run: cargo clippy  --features avx_shaper_fixed_point_paths          -- -D warnings
+      - run: cargo clippy  --features avx_luts                              -- -D warnings
+      - run: cargo clippy  --features avx_shaper_fixed_point_paths,in_place -- -D warnings
+      - run: cargo clippy  --features sse_shaper_paths                      -- -D warnings
+      - run: cargo clippy  --features sse_shaper_optimized_paths            -- -D warnings
+      - run: cargo clippy  --features sse_shaper_fixed_point_paths          -- -D warnings
+      - run: cargo clippy  --features sse_luts                              -- -D warnings
+      - run: cargo clippy  --features sse_shaper_fixed_point_paths,in_place -- -D warnings
 
   clippy_arm:
     name: Clippy ARM
@@ -84,7 +130,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --no-default-features                             -- -D warnings
+      - run: cargo clippy --features neon_shaper_paths                      -- -D warnings
+      - run: cargo clippy --features neon_shaper_optimized_paths            -- -D warnings
+      - run: cargo clippy --features neon_shaper_fixed_point_paths          -- -D warnings
+      - run: cargo clippy --features neon_luts                              -- -D warnings
+      - run: cargo clippy --features neon_shaper_fixed_point_paths,in_place -- -D warnings
 
   fuzz_arm:
     name: Fuzzing ARM
@@ -96,8 +147,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo install cargo-fuzz
-      - run: cargo fuzz run unsafe --no-default-features --features ${{ matrix.feature }} -- -max_total_time=10
-      - run: cargo fuzz run lut --no-default-features --features ${{ matrix.feature }} -- -max_total_time=12
+      - run: cargo fuzz run unsafe --no-default-features --features ${{ matrix.feature }} -- -max_total_time=16
+      - run: cargo fuzz run lut --no-default-features --features ${{ matrix.feature }} -- -max_total_time=16
 
   fuzz_x86_64:
     name: Fuzzing x86_64
@@ -109,8 +160,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo install cargo-fuzz
-      - run: cargo fuzz run unsafe --no-default-features --features ${{ matrix.feature }} -- -max_total_time=12
-      - run: cargo fuzz run lut --no-default-features --features ${{ matrix.feature }} -- -max_total_time=12
+      - run: cargo fuzz run unsafe --no-default-features --features ${{ matrix.feature }} -- -max_total_time=16
+      - run: cargo fuzz run lut --no-default-features --features ${{ matrix.feature }} -- -max_total_time=16
 
   fuzz_reader:
     name: Fuzzing Reader

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,37 +25,33 @@ rand = "0.9"
 
 [features]
 # If no unsafe intrinsics active then `forbid(unsafe)` will be used.
-default = ["avx_shaper_fixed_point_paths", "avx_luts", "sse_shaper_fixed_point_paths", "sse_luts", "neon_shaper_fixed_point_paths", "neon_luts", "lut"]
+default = ["avx_shaper_paths", "sse_shaper_paths", "neon_shaper_paths", "avx_shaper_fixed_point_paths", "avx_luts", "sse_shaper_fixed_point_paths", "sse_luts", "neon_shaper_fixed_point_paths", "neon_luts", "lut"]
 
 # Enables AVX-512 acceleration where possible. This will work only from 1.89 on stable.
 avx512 = []
-# Enables optimize matrix shaper AVX512 paths where all TRC are the same
+# Enables optimize matrix shaper AVX512 paths where all TRC are the same.
 avx512_shaper_optimized_paths = ["avx512"]
-# Enables optimize matrix shaper AVX512 fixed point paths
+# Enables optimize matrix shaper AVX512 fixed point paths.
 avx512_shaper_fixed_point_paths = ["avx512"]
 
 # Enables AVX2 acceleration where possible
 avx = []
-# Enables common matrix shaper AVX paths
+# Enables common matrix shaper AVX paths.
 avx_shaper_paths = ["avx"]
-# Enables optimize matrix shaper AVX paths where all TRC are the same
+# Enables optimize matrix shaper AVX paths where all TRC are the same.
 avx_shaper_optimized_paths = ["avx"]
 # Enables optimize matrix shaper AVX fixed point paths.
-# Fixed point paths are the most agressively optimized paths,
-# hence they are making the biggest contribution to the codesize and compile times.
 avx_shaper_fixed_point_paths = ["avx"]
 # Enables AVX optimized LUT paths. This includes fixes point paths and commons paths.
 avx_luts = ["lut", "avx"]
 
-# Enables SSE4.1 acceleration where possible
+# Enables SSE4.1 acceleration where possible.
 sse = []
-# Enables common matrix shaper SSE paths
+# Enables common matrix shaper SSE paths.
 sse_shaper_paths = ["sse"]
 # Enables optimize matrix shaper SSE paths where all TRC are the same
 sse_shaper_optimized_paths = ["sse"]
 # Enables optimize matrix shaper SSE fixed point paths.
-# Fixed point paths are the most agressively optimized paths,
-# hence they are making the biggest contribution to the codesize and compile times.
 sse_shaper_fixed_point_paths = ["sse"]
 # Enables SSE optimized LUT paths. This includes fixes point paths and commons paths.
 sse_luts = ["lut", "sse"]
@@ -67,8 +63,6 @@ neon_shaper_paths = ["neon"]
 # Enables optimize matrix shaper NEON paths where all TRC are the same.
 neon_shaper_optimized_paths = ["neon"]
 # Enables optimize matrix shaper NEON fixed point paths.
-# Fixed point paths are the most agressively optimized paths,
-# hence they are making the biggest contribution to the codesize and compile times.
 neon_shaper_fixed_point_paths = ["neon"]
 # Enables NEON optimized LUT paths. This includes fixes point paths and commons paths.
 neon_luts = ["lut", "neon"]
@@ -103,6 +97,8 @@ lut = []
 any_to_any = ["lut"]
 # This allows extended range on `f32`/`f64` to work with HDR/WideGamut if neccessary
 extended_range = []
+# Enables in-place transforms.
+in_place = []
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,14 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-image = { version = "=0.25.4", default-features = false }
-moxcms = { path = "../", default-features = false, features = ["sse", "avx512", "neon_shaper_fixed_point_paths", "neon_shaper_paths", "sse_shaper_fixed_point_paths", "sse_shaper_optimized_paths", "sse_shaper_paths", "avx_shaper_paths", "avx_shaper_fixed_point_paths", "avx512_shaper_fixed_point_paths", "avx512_shaper_optimized_paths"] }
+image = { version = "=0.25.4", default-features = false, features = ["jpeg"] }
+moxcms = { path = "../", default-features = false, features = ["sse", "avx512", "neon_shaper_fixed_point_paths", "neon_shaper_optimized_paths", "neon_shaper_paths", "sse_shaper_fixed_point_paths", "sse_shaper_optimized_paths", "sse_shaper_paths", "avx_shaper_paths", "avx_shaper_fixed_point_paths", "avx512_shaper_fixed_point_paths", "avx512_shaper_optimized_paths", "in_place"] }
 lcms2 = "6.1.0"
 #jxl-oxide = {path = "../../../RustroverProjects/jxl-oxide/crates/jxl-oxide", features = ["moxcms", "lcms2"]}
 zune-jpeg = "0.5.0-rc2"
 qcms = "0.3.0"
 rand = "0.9.0"
-libm = "0.2.15"
 
 [dev-dependencies]
 criterion = { version = "0.8.1", features = ["html_reports"] }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -325,9 +325,22 @@ fn main() {
     // fs::write("./gray.icc", encode).unwrap();
 
     let img = DynamicImage::from_decoder(decoder).unwrap();
-    let rgb_f32 = img.to_rgb8();
+    let mut rgb_f32 = img.to_rgb8();
 
     let srgb = moxcms::ColorProfile::new_srgb();
+
+    let i_t = srgb
+        .create_in_place_transform_8bit(
+            moxcms::Layout::Rgb,
+            &ColorProfile::new_adobe_rgb(),
+            TransformOptions {
+                prefer_fixed_point: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    i_t.transform(&mut rgb_f32).unwrap();
 
     let transform = srgb
         .create_transform_8bit(

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,13 +12,13 @@ libfuzzer-sys = "0.4"
 
 [dependencies.moxcms]
 path = ".."
-features = ["options"]
+features = ["options", "in_place"]
 
 [features]
-default = ["moxcms/options"]
-avx = ["moxcms/avx_luts", "moxcms/avx_shaper_fixed_point_paths", "moxcms/avx_shaper_optimized_paths", "moxcms/avx_shaper_paths"]
-sse = ["moxcms/sse_luts", "moxcms/sse_shaper_fixed_point_paths", "moxcms/sse_shaper_optimized_paths", "moxcms/sse_shaper_paths"]
-neon = ["moxcms/neon_luts", "moxcms/neon_shaper_fixed_point_paths", "moxcms/neon_shaper_optimized_paths", "moxcms/neon_shaper_paths"]
+default = ["moxcms/options", "moxcms/in_place"]
+avx = ["moxcms/avx_luts", "moxcms/avx_shaper_fixed_point_paths", "moxcms/avx_shaper_optimized_paths", "moxcms/avx_shaper_paths", "moxcms/in_place"]
+sse = ["moxcms/sse_luts", "moxcms/sse_shaper_fixed_point_paths", "moxcms/sse_shaper_optimized_paths", "moxcms/sse_shaper_paths", "moxcms/in_place"]
+neon = ["moxcms/neon_luts", "moxcms/neon_shaper_fixed_point_paths", "moxcms/neon_shaper_optimized_paths", "moxcms/neon_shaper_paths", "moxcms/in_place"]
 
 [[bin]]
 name = "unsafe"

--- a/src/conversions/avx/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13_opt.rs
@@ -291,6 +291,158 @@ where
 
         Ok(())
     }
+
+    #[cfg(feature = "in_place")]
+    #[target_feature(enable = "avx2")]
+    unsafe fn transform_in_place_avx2(&self, in_out: &mut [T]) -> Result<(), CmsError> {
+        let src_cn = Layout::from(SRC_LAYOUT);
+        assert_eq!(
+            SRC_LAYOUT, DST_LAYOUT,
+            "This is in-place transform, layout must not diverge"
+        );
+        let src_channels = src_cn.channels();
+
+        let mut temporary0 = AvxAlignedU16([0; 16]);
+
+        if in_out.len() % src_channels != 0 {
+            return Err(CmsError::LaneMultipleOfChannels);
+        }
+
+        let t = self.profile.adaptation_matrix.transpose();
+
+        let max_colors = ((1 << self.bit_depth) - 1).as_();
+
+        // safety precondition for linearization table
+        if T::FINITE {
+            let cap = (1 << self.bit_depth) - 1;
+            assert!(self.profile.linear.len() >= cap);
+        } else {
+            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+        }
+
+        let lut_lin = &self.profile.linear;
+
+        unsafe {
+            let m0 = _mm256_setr_epi16(
+                t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0, t.v[0][0],
+                t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
+            );
+            let m2 = _mm256_setr_epi16(
+                t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0, t.v[2][0], 1, t.v[2][1], 1,
+                t.v[2][2], 1, 0, 0,
+            );
+
+            let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
+            let rnd = _mm256_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
+
+            let zeros = _mm256_setzero_si256();
+
+            let v_max_value = _mm256_set1_epi32(self.gamma_lut as i32 - 1);
+
+            let (mut r0, mut g0, mut b0, mut a0);
+            let (mut r1, mut g1, mut b1, mut a1);
+
+            for dst in in_out.chunks_exact_mut(src_channels * 2) {
+                r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize()));
+                g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize()));
+                b0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize()));
+
+                r1 = _xmm_broadcast_epi32(
+                    lut_lin.get_unchecked(dst[src_cn.r_i() + src_channels]._as_usize()),
+                );
+                g1 = _xmm_broadcast_epi32(
+                    lut_lin.get_unchecked(dst[src_cn.g_i() + src_channels]._as_usize()),
+                );
+                b1 = _xmm_broadcast_epi32(
+                    lut_lin.get_unchecked(dst[src_cn.b_i() + src_channels]._as_usize()),
+                );
+
+                a0 = if src_channels == 4 {
+                    dst[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+                a1 = if src_channels == 4 {
+                    dst[src_cn.a_i() + src_channels]
+                } else {
+                    max_colors
+                };
+
+                let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
+                let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
+                let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
+                zg0 = _mm256_slli_epi32::<16>(zg0);
+
+                let zrg0 = _mm256_or_si256(zr0, zg0);
+                let zbz0 = _mm256_or_si256(zb0, rnd);
+
+                let va0 = _mm256_madd_epi16(zrg0, m0);
+                let va1 = _mm256_madd_epi16(zbz0, m2);
+
+                let mut v0 = _mm256_add_epi32(va0, va1);
+
+                v0 = _mm256_srai_epi32::<PRECISION>(v0);
+                v0 = _mm256_max_epi32(v0, zeros);
+                v0 = _mm256_min_epi32(v0, v_max_value);
+
+                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+
+                dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+                dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+                dst[src_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+                if src_channels == 4 {
+                    dst[src_cn.a_i()] = a0;
+                }
+
+                dst[src_cn.r_i() + src_channels] = self.profile.gamma[temporary0.0[8] as usize];
+                dst[src_cn.g_i() + src_channels] = self.profile.gamma[temporary0.0[10] as usize];
+                dst[src_cn.b_i() + src_channels] = self.profile.gamma[temporary0.0[12] as usize];
+                if src_channels == 4 {
+                    dst[src_cn.a_i() + src_channels] = a1;
+                }
+            }
+
+            let dst = in_out.chunks_exact_mut(src_channels * 2).into_remainder();
+
+            for dst in dst.chunks_exact_mut(src_channels) {
+                let r = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize()));
+                let mut g =
+                    _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize()));
+                let b = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize()));
+
+                g = _mm_slli_epi32::<16>(g);
+
+                let a = if src_channels == 4 {
+                    dst[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+
+                let zrg0 = _mm_or_si128(r, g);
+                let zbz0 = _mm_or_si128(b, _mm256_castsi256_si128(rnd));
+
+                let v0 = _mm_madd_epi16(zrg0, _mm256_castsi256_si128(m0));
+                let v1 = _mm_madd_epi16(zbz0, _mm256_castsi256_si128(m2));
+
+                let mut v = _mm_add_epi32(v0, v1);
+
+                v = _mm_srai_epi32::<PRECISION>(v);
+                v = _mm_max_epi32(v, _mm_setzero_si128());
+                v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
+
+                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, v);
+
+                dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+                dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+                dst[src_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+                if src_channels == 4 {
+                    dst[src_cn.a_i()] = a;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl<
@@ -304,5 +456,24 @@ where
 {
     fn transform(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         unsafe { self.transform_avx2(src, dst) }
+    }
+}
+
+#[cfg(feature = "in_place")]
+use crate::InPlaceTransformExecutor;
+
+#[cfg(feature = "in_place")]
+impl<
+    T: Copy + PointeeSizeExpressible + 'static + Default,
+    const SRC_LAYOUT: u8,
+    const DST_LAYOUT: u8,
+    const PRECISION: i32,
+> InPlaceTransformExecutor<T>
+    for TransformShaperRgbQ2_13OptAvx<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+where
+    u32: AsPrimitive<T>,
+{
+    fn transform(&self, in_out: &mut [T]) -> Result<(), CmsError> {
+        unsafe { self.transform_in_place_avx2(in_out) }
     }
 }

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -64,6 +64,8 @@ mod transform_lut3_to_4;
 mod transform_lut4_to_3;
 mod xyz_lab;
 
+#[cfg(feature = "in_place")]
+pub(crate) use gray2rgb::make_gray_to_gray_in_place;
 pub(crate) use gray2rgb::{make_gray_to_unfused, make_gray_to_x};
 #[cfg(feature = "extended_range")]
 pub(crate) use gray2rgb_extended::{make_gray_to_one_trc_extended, make_gray_to_rgb_extended};

--- a/src/conversions/rgb_xyz_factory.rs
+++ b/src/conversions/rgb_xyz_factory.rs
@@ -26,6 +26,8 @@
  * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#[cfg(feature = "in_place")]
+use crate::InPlaceTransformExecutor;
 use crate::conversions::TransformMatrixShaper;
 use crate::conversions::rgbxyz::{
     TransformMatrixShaperOptimized, make_rgb_xyz_rgb_transform, make_rgb_xyz_rgb_transform_opt,
@@ -44,6 +46,17 @@ pub(crate) trait RgbXyzFactory<T: Clone + AsPrimitive<usize> + Default> {
         profile: TransformMatrixShaper<T, LINEAR_CAP>,
         transform_options: TransformOptions,
     ) -> Result<Arc<dyn TransformExecutor<T> + Send + Sync>, CmsError>;
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaper<T, LINEAR_CAP>,
+        transform_options: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<T> + Send + Sync>, CmsError>;
 }
 
 pub(crate) trait RgbXyzFactoryOpt<T: Clone + AsPrimitive<usize> + Default> {
@@ -57,6 +70,17 @@ pub(crate) trait RgbXyzFactoryOpt<T: Clone + AsPrimitive<usize> + Default> {
         profile: TransformMatrixShaperOptimized<T, LINEAR_CAP>,
         transform_options: TransformOptions,
     ) -> Result<Arc<dyn TransformExecutor<T> + Send + Sync>, CmsError>;
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_optimized_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaperOptimized<T, LINEAR_CAP>,
+        transform_options: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<T> + Send + Sync>, CmsError>;
 }
 
 impl RgbXyzFactory<u16> for u16 {
@@ -69,6 +93,20 @@ impl RgbXyzFactory<u16> for u16 {
         make_rgb_xyz_rgb_transform::<u16, LINEAR_CAP>(
             src_layout, dst_layout, profile, GAMMA_LUT, BIT_DEPTH,
         )
+    }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaper<u16, LINEAR_CAP>,
+        _: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<u16> + Send + Sync>, CmsError> {
+        use crate::conversions::rgbxyz::make_in_place_rgb_xyz_transform;
+        make_in_place_rgb_xyz_transform::<u16, LINEAR_CAP>(layout, profile, GAMMA_LUT, BIT_DEPTH)
     }
 }
 
@@ -83,6 +121,20 @@ impl RgbXyzFactory<f32> for f32 {
             src_layout, dst_layout, profile, GAMMA_LUT, BIT_DEPTH,
         )
     }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaper<f32, LINEAR_CAP>,
+        _: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<f32> + Send + Sync>, CmsError> {
+        use crate::conversions::rgbxyz::make_in_place_rgb_xyz_transform;
+        make_in_place_rgb_xyz_transform::<f32, LINEAR_CAP>(layout, profile, GAMMA_LUT, BIT_DEPTH)
+    }
 }
 
 impl RgbXyzFactory<f64> for f64 {
@@ -96,6 +148,20 @@ impl RgbXyzFactory<f64> for f64 {
             src_layout, dst_layout, profile, GAMMA_LUT, BIT_DEPTH,
         )
     }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaper<f64, LINEAR_CAP>,
+        _: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<f64> + Send + Sync>, CmsError> {
+        use crate::conversions::rgbxyz::make_in_place_rgb_xyz_transform;
+        make_in_place_rgb_xyz_transform::<f64, LINEAR_CAP>(layout, profile, GAMMA_LUT, BIT_DEPTH)
+    }
 }
 
 impl RgbXyzFactory<u8> for u8 {
@@ -106,6 +172,20 @@ impl RgbXyzFactory<u8> for u8 {
         _: TransformOptions,
     ) -> Result<Arc<dyn TransformExecutor<u8> + Send + Sync>, CmsError> {
         make_rgb_xyz_rgb_transform::<u8, LINEAR_CAP>(src_layout, dst_layout, profile, GAMMA_LUT, 8)
+    }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaper<u8, LINEAR_CAP>,
+        _: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<u8> + Send + Sync>, CmsError> {
+        use crate::conversions::rgbxyz::make_in_place_rgb_xyz_transform;
+        make_in_place_rgb_xyz_transform::<u8, LINEAR_CAP>(layout, profile, GAMMA_LUT, BIT_DEPTH)
     }
 }
 
@@ -174,6 +254,69 @@ impl RgbXyzFactoryOpt<u16> for u16 {
             src_layout, dst_layout, profile, GAMMA_LUT, BIT_DEPTH,
         )
     }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_optimized_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaperOptimized<u16, LINEAR_CAP>,
+        transform_options: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<u16> + Send + Sync>, CmsError> {
+        if transform_options.prefer_fixed_point && BIT_DEPTH < 16 {
+            #[cfg(all(
+                target_arch = "aarch64",
+                feature = "in_place",
+                feature = "neon_shaper_fixed_point_paths"
+            ))]
+            {
+                use crate::conversions::rgbxyz::make_rgb_xyz_in_place_transform_q2_13_opt;
+                return make_rgb_xyz_in_place_transform_q2_13_opt::<
+                    u16,
+                    LINEAR_CAP,
+                    FIXED_POINT_SCALE,
+                >(layout, profile, GAMMA_LUT, BIT_DEPTH);
+            }
+
+            #[cfg(all(
+                target_arch = "x86_64",
+                feature = "in_place",
+                feature = "avx_shaper_fixed_point_paths"
+            ))]
+            {
+                if std::arch::is_x86_feature_detected!("avx2") {
+                    use crate::conversions::rgbxyz::make_avx_rgb_xyz_in_place_transform_q2_13_opt;
+                    return make_avx_rgb_xyz_in_place_transform_q2_13_opt::<
+                        u16,
+                        LINEAR_CAP,
+                        FIXED_POINT_SCALE,
+                    >(layout, profile, GAMMA_LUT, BIT_DEPTH);
+                }
+            }
+
+            #[cfg(all(
+                any(target_arch = "x86_64", target_arch = "x86"),
+                feature = "in_place",
+                feature = "sse_shaper_fixed_point_paths"
+            ))]
+            {
+                if std::arch::is_x86_feature_detected!("sse4.1") {
+                    use crate::conversions::rgbxyz::make_sse_rgb_xyz_in_place_transform_q2_13_opt;
+                    return make_sse_rgb_xyz_in_place_transform_q2_13_opt::<
+                        u16,
+                        LINEAR_CAP,
+                        FIXED_POINT_SCALE,
+                    >(layout, profile, GAMMA_LUT, BIT_DEPTH);
+                }
+            }
+        }
+        use crate::conversions::rgbxyz::make_rgb_xyz_in_place_transform_opt;
+        make_rgb_xyz_in_place_transform_opt::<u16, LINEAR_CAP>(
+            layout, profile, GAMMA_LUT, BIT_DEPTH,
+        )
+    }
 }
 
 impl RgbXyzFactoryOpt<f32> for f32 {
@@ -235,6 +378,22 @@ impl RgbXyzFactoryOpt<f32> for f32 {
             src_layout, dst_layout, profile, GAMMA_LUT, BIT_DEPTH,
         )
     }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_optimized_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaperOptimized<f32, LINEAR_CAP>,
+        _: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<f32> + Send + Sync>, CmsError> {
+        use crate::conversions::rgbxyz::make_rgb_xyz_in_place_transform_opt;
+        make_rgb_xyz_in_place_transform_opt::<f32, LINEAR_CAP>(
+            layout, profile, GAMMA_LUT, BIT_DEPTH,
+        )
+    }
 }
 
 impl RgbXyzFactoryOpt<f64> for f64 {
@@ -261,6 +420,22 @@ impl RgbXyzFactoryOpt<f64> for f64 {
         }
         make_rgb_xyz_rgb_transform_opt::<f64, LINEAR_CAP>(
             src_layout, dst_layout, profile, GAMMA_LUT, BIT_DEPTH,
+        )
+    }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_optimized_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaperOptimized<f64, LINEAR_CAP>,
+        _: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<f64> + Send + Sync>, CmsError> {
+        use crate::conversions::rgbxyz::make_rgb_xyz_in_place_transform_opt;
+        make_rgb_xyz_in_place_transform_opt::<f64, LINEAR_CAP>(
+            layout, profile, GAMMA_LUT, BIT_DEPTH,
         )
     }
 }
@@ -323,5 +498,66 @@ impl RgbXyzFactoryOpt<u8> for u8 {
                 src_layout, dst_layout, profile, GAMMA_LUT, 8,
             )
         }
+    }
+
+    #[cfg(feature = "in_place")]
+    fn make_in_place_optimized_transform<
+        const LINEAR_CAP: usize,
+        const GAMMA_LUT: usize,
+        const BIT_DEPTH: usize,
+    >(
+        layout: Layout,
+        profile: TransformMatrixShaperOptimized<u8, LINEAR_CAP>,
+        transform_options: TransformOptions,
+    ) -> Result<Arc<dyn InPlaceTransformExecutor<u8> + Send + Sync>, CmsError> {
+        if transform_options.prefer_fixed_point {
+            #[cfg(all(
+                target_arch = "aarch64",
+                feature = "in_place",
+                feature = "neon_shaper_fixed_point_paths"
+            ))]
+            {
+                use crate::conversions::rgbxyz::make_rgb_xyz_in_place_transform_q2_13_opt;
+                return make_rgb_xyz_in_place_transform_q2_13_opt::<
+                    u8,
+                    LINEAR_CAP,
+                    FIXED_POINT_SCALE,
+                >(layout, profile, GAMMA_LUT, 8);
+            }
+
+            #[cfg(all(
+                target_arch = "x86_64",
+                feature = "in_place",
+                feature = "avx_shaper_fixed_point_paths"
+            ))]
+            {
+                if std::arch::is_x86_feature_detected!("avx2") {
+                    use crate::conversions::rgbxyz::make_avx_rgb_xyz_in_place_transform_q2_13_opt;
+                    return make_avx_rgb_xyz_in_place_transform_q2_13_opt::<
+                        u8,
+                        LINEAR_CAP,
+                        FIXED_POINT_SCALE,
+                    >(layout, profile, GAMMA_LUT, 8);
+                }
+            }
+
+            #[cfg(all(
+                any(target_arch = "x86_64", target_arch = "x86"),
+                feature = "in_place",
+                feature = "sse_shaper_fixed_point_paths"
+            ))]
+            {
+                if std::arch::is_x86_feature_detected!("sse4.1") {
+                    use crate::conversions::rgbxyz::make_sse_rgb_xyz_in_place_transform_q2_13_opt;
+                    return make_sse_rgb_xyz_in_place_transform_q2_13_opt::<
+                        u8,
+                        LINEAR_CAP,
+                        FIXED_POINT_SCALE,
+                    >(layout, profile, GAMMA_LUT, 8);
+                }
+            }
+        }
+        use crate::conversions::rgbxyz::make_rgb_xyz_in_place_transform_opt;
+        make_rgb_xyz_in_place_transform_opt::<u8, LINEAR_CAP>(layout, profile, GAMMA_LUT, 8)
     }
 }

--- a/src/conversions/sse/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/sse/rgb_xyz_q2_13_opt.rs
@@ -156,6 +156,94 @@ where
 
         Ok(())
     }
+
+    #[cfg(feature = "in_place")]
+    #[target_feature(enable = "sse4.1")]
+    unsafe fn transform_in_place_impl(&self, in_out: &mut [T]) -> Result<(), CmsError> {
+        let src_cn = Layout::from(SRC_LAYOUT);
+        let src_channels = src_cn.channels();
+
+        assert_eq!(
+            SRC_LAYOUT, DST_LAYOUT,
+            "This is in-place transform, layout must not diverge"
+        );
+
+        let mut temporary = SseAlignedU16([0; 8]);
+
+        if in_out.len() % src_channels != 0 {
+            return Err(CmsError::LaneMultipleOfChannels);
+        }
+
+        let t = self.profile.adaptation_matrix.transpose();
+
+        let max_colors = ((1 << self.bit_depth) - 1).as_();
+
+        unsafe {
+            let m0 = _mm_setr_epi16(
+                t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
+            );
+            let m2 = _mm_setr_epi16(t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0);
+
+            let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
+            let rnd = _mm_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
+
+            let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
+
+            // safety precondition for linearization table
+            if T::FINITE {
+                let cap = (1 << self.bit_depth) - 1;
+                assert!(self.profile.linear.len() >= cap);
+            } else {
+                assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+            }
+
+            let lut_lin = &self.profile.linear;
+
+            for dst in in_out.chunks_exact_mut(src_channels) {
+                let rp = lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize());
+                let gp = lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize());
+                let bp = lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize());
+
+                let mut r = _xmm_load_epi32(rp);
+                let mut g = _xmm_load_epi32(gp);
+                let mut b = _xmm_load_epi32(bp);
+                let a = if src_channels == 4 {
+                    dst[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+
+                r = _mm_shuffle_epi32::<0>(r);
+                g = _mm_shuffle_epi32::<0>(g);
+                b = _mm_shuffle_epi32::<0>(b);
+
+                g = _mm_slli_epi32::<16>(g);
+
+                let zrg0 = _mm_or_si128(r, g);
+                let zbz0 = _mm_or_si128(b, rnd);
+
+                let v0 = _mm_madd_epi16(zrg0, m0);
+                let v1 = _mm_madd_epi16(zbz0, m2);
+
+                let mut v = _mm_add_epi32(v0, v1);
+
+                v = _mm_srai_epi32::<PRECISION>(v);
+                v = _mm_max_epi32(v, _mm_setzero_si128());
+                v = _mm_min_epi32(v, v_max_value);
+
+                _mm_store_si128(temporary.0.as_mut_ptr() as *mut _, v);
+
+                dst[src_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
+                dst[src_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
+                dst[src_cn.b_i()] = self.profile.gamma[temporary.0[4] as usize];
+                if src_channels == 4 {
+                    dst[src_cn.a_i()] = a;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl<
@@ -169,5 +257,23 @@ where
 {
     fn transform(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         unsafe { self.transform_impl(src, dst) }
+    }
+}
+
+#[cfg(feature = "in_place")]
+use crate::InPlaceTransformExecutor;
+
+#[cfg(feature = "in_place")]
+impl<
+    T: Copy + PointeeSizeExpressible + 'static + Default,
+    const SRC_LAYOUT: u8,
+    const DST_LAYOUT: u8,
+    const PRECISION: i32,
+> InPlaceTransformExecutor<T> for TransformShaperQ2_13OptSse<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+where
+    u32: AsPrimitive<T>,
+{
+    fn transform(&self, in_out: &mut [T]) -> Result<(), CmsError> {
+        unsafe { self.transform_in_place_impl(in_out) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,9 @@ pub use profile::{
 pub use rgb::{FusedExp, FusedExp2, FusedExp10, FusedLog, FusedLog2, FusedLog10, FusedPow, Rgb};
 pub use srlab2::Srlab2;
 pub use transform::{
-    BarycentricWeightScale, InPlaceStage, InterpolationMethod, Layout, PointeeSizeExpressible,
-    Stage, Transform8BitExecutor, Transform16BitExecutor, TransformExecutor, TransformF32Executor,
-    TransformF64Executor, TransformOptions,
+    BarycentricWeightScale, InPlaceStage, InPlaceTransformExecutor, InterpolationMethod, Layout,
+    PointeeSizeExpressible, Stage, Transform8BitExecutor, Transform16BitExecutor,
+    TransformExecutor, TransformF32Executor, TransformF64Executor, TransformOptions,
 };
 pub use trc::{
     GammaLutInterpolate, ParametricCurve, ToneCurveEvaluator, ToneReprCurve, curve_from_gamma,


### PR DESCRIPTION
@197g 

In place processing will be supported starting with the next minor release.
Currently, only matrix shaper transforms RGBX → RGBX and GrayX → GrayX are supported, with no channel expansion or reduction.
For the acceleration paths only `u8` and `u16` is supported with SIMD with only fixed point implementations where all TRCs are the same are supported for code generation and maintenance reasons.

However, for codegen I actually think Rust + LLVM recognized almost the same code and using the same code paths for out of place and in place transform, so from a codegen perspective it doesn’t seem problematic at all.