### PR TITLE
fix(neon): use vr1 instead of vr0 for second pixel's blue channel

### DIFF
--- a/src/conversions/neon/rgb_xyz_q1_30_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q1_30_opt.rs
@@ -196,7 +196,7 @@ where
                     dst0[dst_cn.g_i() + dst_channels] =
                         self.profile.gamma[vget_lane_u16::<1>(vr1) as usize];
                     dst0[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
+                        self.profile.gamma[vget_lane_u16::<2>(vr1) as usize];
                     if dst_channels == 4 {
                         dst0[dst_cn.a_i() + dst_channels] = a1;
                     }

--- a/src/conversions/neon/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q2_13_opt.rs
@@ -255,7 +255,7 @@ where
                     dst0[dst_cn.g_i() + dst_channels] =
                         self.profile.gamma[vget_lane_u16::<1>(vr1) as usize];
                     dst0[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
+                        self.profile.gamma[vget_lane_u16::<2>(vr1) as usize];
                     if dst_channels == 4 {
                         dst0[dst_cn.a_i() + dst_channels] = a1;
                     }
@@ -343,7 +343,7 @@ where
                     dst0[dst_cn.g_i() + dst_channels] =
                         self.profile.gamma[vget_lane_u16::<1>(vr1) as usize];
                     dst0[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
+                        self.profile.gamma[vget_lane_u16::<2>(vr1) as usize];
                     if dst_channels == 4 {
                         dst0[dst_cn.a_i() + dst_channels] = a1;
                     }
@@ -556,7 +556,7 @@ where
                     dst0[src_cn.g_i() + src_channels] =
                         self.profile.gamma[vget_lane_u16::<1>(vr1) as usize];
                     dst0[src_cn.b_i() + src_channels] =
-                        self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
+                        self.profile.gamma[vget_lane_u16::<2>(vr1) as usize];
                     if src_channels == 4 {
                         dst0[src_cn.a_i() + src_channels] = a1;
                     }


### PR DESCRIPTION
## Summary

In the ARM64 NEON fixed-point RGB<->XYZ conversion paths, the blue channel for the second pixel was incorrectly reading from `vr0` (first pixel's result) instead of `vr1` (second pixel's result).

**Bug pattern:**
```rust
dst0[dst_cn.r_i() + dst_channels] = gamma[vget_lane_u16::<0>(vr1)]; // correct
dst0[dst_cn.g_i() + dst_channels] = gamma[vget_lane_u16::<1>(vr1)]; // correct
dst0[dst_cn.b_i() + dst_channels] = gamma[vget_lane_u16::<2>(vr0)]; // BUG: should be vr1
```

This caused blue channel data from the first pixel to be incorrectly written to the second pixel's blue channel, resulting in color corruption when processing two pixels at a time on ARM64.

## Changes

Fixed 4 occurrences across 2 files:
- `rgb_xyz_q2_13_opt.rs`: 3 occurrences (lines 258, 346, 559)
- `rgb_xyz_q1_30_opt.rs`: 1 occurrence (line 199)

## Testing

Found via visual inspection while reviewing the SIMD code paths. The bug affects ARM64 NEON builds only and would manifest as incorrect blue channel values on every second pixel in 2-pixel-at-a-time processing loops.