### PR TITLE
Replace unsafe get_unchecked with safe bounded indexing

### DIFF
--- a/src/conversions/avx/interpolator.rs
+++ b/src/conversions/avx/interpolator.rs
@@ -57,7 +57,7 @@ pub(crate) struct PyramidAvxFmaDouble<const GRID_SIZE: usize> {}
 #[cfg(feature = "options")]
 pub(crate) struct TetrahedralAvxFmaDouble<const GRID_SIZE: usize> {}
 
-pub(crate) trait AvxMdInterpolationDouble {
+pub(crate) trait AvxMdInterpolationDouble<const BINS: usize> {
     fn inter3_sse(
         &self,
         table0: &[SseAlignedF32],
@@ -65,18 +65,18 @@ pub(crate) trait AvxMdInterpolationDouble {
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
     ) -> (AvxVectorSse, AvxVectorSse);
 }
 
-pub(crate) trait AvxMdInterpolation {
+pub(crate) trait AvxMdInterpolation<const BINS: usize> {
     fn inter3_sse(
         &self,
         table: &[SseAlignedF32],
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
     ) -> AvxVectorSse;
 }
 
@@ -281,17 +281,17 @@ impl<const GRID_SIZE: usize> Fetcher<AvxVectorSse> for TetrahedralAvxSseFetchVec
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxFma<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<AvxVectorSse>,
     ) -> AvxVectorSse {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -351,14 +351,16 @@ impl<const GRID_SIZE: usize> TetrahedralAvxFma<GRID_SIZE> {
 
 macro_rules! define_interp_avx {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> AvxMdInterpolation for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolation<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_sse(
                 &self,
                 table: &[SseAlignedF32],
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<f32>],
+                lut: &[BarycentricWeight<f32>; BINS],
             ) -> AvxVectorSse {
                 unsafe {
                     self.interpolate(
@@ -377,7 +379,9 @@ macro_rules! define_interp_avx {
 #[cfg(feature = "options")]
 macro_rules! define_interp_avx_d {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolationDouble<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_sse(
                 &self,
                 table0: &[SseAlignedF32],
@@ -385,7 +389,7 @@ macro_rules! define_interp_avx_d {
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<f32>],
+                lut: &[BarycentricWeight<f32>; BINS],
             ) -> (AvxVectorSse, AvxVectorSse) {
                 unsafe {
                     self.interpolate(
@@ -415,7 +419,9 @@ define_interp_avx_d!(PrismaticAvxFmaDouble);
 define_interp_avx_d!(PyramidAvxFmaDouble);
 
 #[cfg(feature = "options")]
-impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for TetrahedralAvxFmaDouble<GRID_SIZE> {
+impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolationDouble<BINS>
+    for TetrahedralAvxFmaDouble<GRID_SIZE>
+{
     fn inter3_sse(
         &self,
         table0: &[SseAlignedF32],
@@ -423,7 +429,7 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for TetrahedralAvxFmaDoubl
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
     ) -> (AvxVectorSse, AvxVectorSse) {
         unsafe {
             self.interpolate(
@@ -440,7 +446,9 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for TetrahedralAvxFmaDoubl
     }
 }
 
-impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for TrilinearAvxFmaDouble<GRID_SIZE> {
+impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolationDouble<BINS>
+    for TrilinearAvxFmaDouble<GRID_SIZE>
+{
     fn inter3_sse(
         &self,
         table0: &[SseAlignedF32],
@@ -448,7 +456,7 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for TrilinearAvxFmaDouble<
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
     ) -> (AvxVectorSse, AvxVectorSse) {
         unsafe {
             self.interpolate(
@@ -468,17 +476,17 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationDouble for TrilinearAvxFmaDouble<
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalAvxFma<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<AvxVectorSse>,
     ) -> AvxVectorSse {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -555,17 +563,17 @@ impl<const GRID_SIZE: usize> PyramidalAvxFma<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxFma<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<AvxVectorSse>,
     ) -> AvxVectorSse {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -630,18 +638,18 @@ impl<const GRID_SIZE: usize> PrismaticAvxFma<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxFmaDouble<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r0: impl Fetcher<AvxVectorSse>,
         r1: impl Fetcher<AvxVectorSse>,
     ) -> (AvxVectorSse, AvxVectorSse) {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -733,18 +741,18 @@ impl<const GRID_SIZE: usize> PrismaticAvxFmaDouble<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidAvxFmaDouble<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r0: impl Fetcher<AvxVectorSse>,
         r1: impl Fetcher<AvxVectorSse>,
     ) -> (AvxVectorSse, AvxVectorSse) {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -855,17 +863,17 @@ impl<const GRID_SIZE: usize> PyramidAvxFmaDouble<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxFmaDouble<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         rv: impl Fetcher<AvxVector>,
     ) -> (AvxVectorSse, AvxVectorSse) {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -929,17 +937,17 @@ impl<const GRID_SIZE: usize> TetrahedralAvxFmaDouble<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearAvxFmaDouble<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         rv: impl Fetcher<AvxVector>,
     ) -> (AvxVectorSse, AvxVectorSse) {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -986,17 +994,17 @@ impl<const GRID_SIZE: usize> TrilinearAvxFmaDouble<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearAvxFma<GRID_SIZE> {
     #[target_feature(enable = "avx2", enable = "fma")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<AvxVectorSse>,
     ) -> AvxVectorSse {
-        let lut_r = unsafe { lut.get_unchecked(in_r) };
-        let lut_g = unsafe { lut.get_unchecked(in_g) };
-        let lut_b = unsafe { lut.get_unchecked(in_b) };
+        let lut_r = &lut[in_r & (BINS - 1)];
+        let lut_g = &lut[in_g & (BINS - 1)];
+        let lut_b = &lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;

--- a/src/conversions/avx/interpolator_q0_15.rs
+++ b/src/conversions/avx/interpolator_q0_15.rs
@@ -57,7 +57,7 @@ pub(crate) struct PyramidAvxFmaQ0_15Double<const GRID_SIZE: usize> {}
 #[cfg(feature = "options")]
 pub(crate) struct TetrahedralAvxQ0_15Double<const GRID_SIZE: usize> {}
 
-pub(crate) trait AvxMdInterpolationQ0_15Double {
+pub(crate) trait AvxMdInterpolationQ0_15Double<const BINS: usize> {
     fn inter3_sse(
         &self,
         table0: &[AvxAlignedI16],
@@ -65,18 +65,18 @@ pub(crate) trait AvxMdInterpolationQ0_15Double {
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
     ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse);
 }
 
-pub(crate) trait AvxMdInterpolationQ0_15 {
+pub(crate) trait AvxMdInterpolationQ0_15<const BINS: usize> {
     fn inter3_sse(
         &self,
         table: &[AvxAlignedI16],
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
     ) -> AvxVectorQ0_15Sse;
 }
 
@@ -265,17 +265,17 @@ impl<const GRID_SIZE: usize> Fetcher<AvxVectorQ0_15Sse>
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxQ0_15<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<AvxVectorQ0_15Sse>,
     ) -> AvxVectorQ0_15Sse {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -335,14 +335,16 @@ impl<const GRID_SIZE: usize> TetrahedralAvxQ0_15<GRID_SIZE> {
 
 macro_rules! define_interp_avx {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15 for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolationQ0_15<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_sse(
                 &self,
                 table: &[AvxAlignedI16],
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<i16>],
+                lut: &[BarycentricWeight<i16>; BINS],
             ) -> AvxVectorQ0_15Sse {
                 unsafe {
                     self.interpolate(
@@ -361,7 +363,9 @@ macro_rules! define_interp_avx {
 #[cfg(feature = "options")]
 macro_rules! define_interp_avx_d {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15Double for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolationQ0_15Double<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_sse(
                 &self,
                 table0: &[AvxAlignedI16],
@@ -369,7 +373,7 @@ macro_rules! define_interp_avx_d {
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<i16>],
+                lut: &[BarycentricWeight<i16>; BINS],
             ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse) {
                 unsafe {
                     self.interpolate(
@@ -399,7 +403,7 @@ define_interp_avx_d!(PrismaticAvxQ0_15Double);
 define_interp_avx_d!(PyramidAvxFmaQ0_15Double);
 
 #[cfg(feature = "options")]
-impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15Double
+impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolationQ0_15Double<BINS>
     for TetrahedralAvxQ0_15Double<GRID_SIZE>
 {
     fn inter3_sse(
@@ -409,7 +413,7 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15Double
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
     ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse) {
         unsafe {
             self.interpolate(
@@ -426,7 +430,9 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15Double
     }
 }
 
-impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15Double for TrilinearAvxQ0_15Double<GRID_SIZE> {
+impl<const GRID_SIZE: usize, const BINS: usize> AvxMdInterpolationQ0_15Double<BINS>
+    for TrilinearAvxQ0_15Double<GRID_SIZE>
+{
     fn inter3_sse(
         &self,
         table0: &[AvxAlignedI16],
@@ -434,7 +440,7 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15Double for TrilinearAvxQ0_15
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
     ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse) {
         unsafe {
             self.interpolate(
@@ -454,17 +460,17 @@ impl<const GRID_SIZE: usize> AvxMdInterpolationQ0_15Double for TrilinearAvxQ0_15
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalAvxQ0_15<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<AvxVectorQ0_15Sse>,
     ) -> AvxVectorQ0_15Sse {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -541,17 +547,17 @@ impl<const GRID_SIZE: usize> PyramidalAvxQ0_15<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxQ0_15<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<AvxVectorQ0_15Sse>,
     ) -> AvxVectorQ0_15Sse {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -616,18 +622,18 @@ impl<const GRID_SIZE: usize> PrismaticAvxQ0_15<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r0: impl Fetcher<AvxVectorQ0_15Sse>,
         r1: impl Fetcher<AvxVectorQ0_15Sse>,
     ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -719,18 +725,18 @@ impl<const GRID_SIZE: usize> PrismaticAvxQ0_15Double<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidAvxFmaQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r0: impl Fetcher<AvxVectorQ0_15Sse>,
         r1: impl Fetcher<AvxVectorQ0_15Sse>,
     ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -841,17 +847,17 @@ impl<const GRID_SIZE: usize> PyramidAvxFmaQ0_15Double<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         rv: impl Fetcher<AvxVectorQ0_15>,
     ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -915,17 +921,17 @@ impl<const GRID_SIZE: usize> TetrahedralAvxQ0_15Double<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearAvxQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         rv: impl Fetcher<AvxVectorQ0_15>,
     ) -> (AvxVectorQ0_15Sse, AvxVectorQ0_15Sse) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -972,17 +978,17 @@ impl<const GRID_SIZE: usize> TrilinearAvxQ0_15Double<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearAvxQ0_15<GRID_SIZE> {
     #[target_feature(enable = "avx2")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<AvxVectorQ0_15Sse>,
     ) -> AvxVectorQ0_15Sse {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;

--- a/src/conversions/avx/lut4_to_3.rs
+++ b/src/conversions/avx/lut4_to_3.rs
@@ -81,7 +81,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn AvxMdInterpolationDouble + Send + Sync>,
+        interpolator: Box<dyn AvxMdInterpolationDouble<BINS> + Send + Sync>,
     ) {
         let cn = Layout::from(LAYOUT);
         let channels = cn.channels();
@@ -119,14 +119,8 @@ where
             let table1 = &self.lut[(w * grid_size3) as usize..];
             let table2 = &self.lut[(w_n * grid_size3) as usize..];
 
-            let v = interpolator.inter3_sse(
-                table1,
-                table2,
-                c.as_(),
-                m.as_(),
-                y.as_(),
-                self.weights.as_slice(),
-            );
+            let v =
+                interpolator.inter3_sse(table1, table2, c.as_(), m.as_(), y.as_(), &self.weights);
             let (a0, b0) = (v.0.v, v.1.v);
 
             if T::FINITE {

--- a/src/conversions/avx/lut4_to_3_q0_15.rs
+++ b/src/conversions/avx/lut4_to_3_q0_15.rs
@@ -73,7 +73,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn AvxMdInterpolationQ0_15Double + Send + Sync>,
+        interpolator: Box<dyn AvxMdInterpolationQ0_15Double<BINS> + Send + Sync>,
     ) {
         let cn = Layout::from(LAYOUT);
         let channels = cn.channels();
@@ -118,14 +118,8 @@ where
             let table1 = &self.lut[(w * grid_size3) as usize..];
             let table2 = &self.lut[(w_n * grid_size3) as usize..];
 
-            let v = interpolator.inter3_sse(
-                table1,
-                table2,
-                c.as_(),
-                m.as_(),
-                y.as_(),
-                self.weights.as_slice(),
-            );
+            let v =
+                interpolator.inter3_sse(table1, table2, c.as_(), m.as_(), y.as_(), &self.weights);
             let (a0, b0) = (v.0.v, v.1.v);
 
             let hp = _mm_mulhrs_epi16(_mm_set1_epi16(t_n), a0);

--- a/src/conversions/avx/rgb_xyz_opt.rs
+++ b/src/conversions/avx/rgb_xyz_opt.rs
@@ -27,8 +27,8 @@
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #![cfg(feature = "avx_shaper_optimized_paths")]
+use crate::conversions::TransformMatrixShaperOptimized;
 use crate::conversions::avx::AvxAlignedU16;
-use crate::conversions::rgbxyz::TransformMatrixShaperOptimizedV;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
@@ -38,8 +38,9 @@ pub(crate) struct TransformShaperRgbOptAvx<
     T: Clone + Copy + 'static + PointeeSizeExpressible + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
 > {
-    pub(crate) profile: TransformMatrixShaperOptimizedV<T>,
+    pub(crate) profile: TransformMatrixShaperOptimized<T, LINEAR_CAP>,
     pub(crate) bit_depth: usize,
     pub(crate) gamma_lut: usize,
 }
@@ -48,7 +49,8 @@ impl<
     T: Clone + Copy + 'static + PointeeSizeExpressible + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
-> TransformShaperRgbOptAvx<T, SRC_LAYOUT, DST_LAYOUT>
+    const LINEAR_CAP: usize,
+> TransformShaperRgbOptAvx<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP>
 where
     u32: AsPrimitive<T>,
 {
@@ -75,14 +77,6 @@ where
 
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
-
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
 
         let lut_lin = &self.profile.linear;
 
@@ -111,17 +105,17 @@ where
             let (mut r1, mut g1, mut b1, mut a1);
 
             for (src, dst) in src_iter.zip(dst_iter) {
-                r0 = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                g0 = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                b0 = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
+                r0 = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)]);
+                g0 = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)]);
+                b0 = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)]);
                 r1 = _mm_broadcast_ss(
-                    lut_lin.get_unchecked(src[src_cn.r_i() + src_channels]._as_usize()),
+                    &lut_lin[src[src_cn.r_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 g1 = _mm_broadcast_ss(
-                    lut_lin.get_unchecked(src[src_cn.g_i() + src_channels]._as_usize()),
+                    &lut_lin[src[src_cn.g_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 b1 = _mm_broadcast_ss(
-                    lut_lin.get_unchecked(src[src_cn.b_i() + src_channels]._as_usize()),
+                    &lut_lin[src[src_cn.b_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 a0 = if src_channels == 4 {
                     src[src_cn.a_i()]
@@ -179,9 +173,12 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let r = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                let g = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                let b = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
+                let r =
+                    _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)]);
+                let g =
+                    _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)]);
+                let b =
+                    _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)]);
                 let a = if src_channels == 4 {
                     src[src_cn.a_i()]
                 } else {
@@ -224,7 +221,8 @@ impl<
     T: Clone + Copy + 'static + PointeeSizeExpressible + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
-> TransformExecutor<T> for TransformShaperRgbOptAvx<T, SRC_LAYOUT, DST_LAYOUT>
+    const LINEAR_CAP: usize,
+> TransformExecutor<T> for TransformShaperRgbOptAvx<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP>
 where
     u32: AsPrimitive<T>,
 {

--- a/src/conversions/avx/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13_opt.rs
@@ -28,7 +28,7 @@
  */
 #![cfg(feature = "avx_shaper_fixed_point_paths")]
 use crate::conversions::avx::AvxAlignedU16;
-use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
+use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFixedPointOpt;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
@@ -44,9 +44,10 @@ pub(crate) struct TransformShaperRgbQ2_13OptAvx<
     T: Copy,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
 > {
-    pub(crate) profile: TransformMatrixShaperFpOptVec<i32, i16, T>,
+    pub(crate) profile: TransformMatrixShaperFixedPointOpt<i32, i16, T, LINEAR_CAP>,
     pub(crate) bit_depth: usize,
     pub(crate) gamma_lut: usize,
 }
@@ -55,8 +56,9 @@ impl<
     T: Copy + PointeeSizeExpressible + 'static,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
-> TransformShaperRgbQ2_13OptAvx<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+> TransformShaperRgbQ2_13OptAvx<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP, PRECISION>
 where
     u32: AsPrimitive<T>,
 {
@@ -83,14 +85,6 @@ where
 
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
 
         unsafe {
@@ -116,18 +110,24 @@ where
             let mut src_iter = src.chunks_exact(src_channels * 2);
 
             if let Some(src0) = src_iter.next() {
-                r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize()));
-                g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize()));
-                b0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize()));
+                r0 = _xmm_broadcast_epi32(
+                    &lut_lin[src0[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                g0 = _xmm_broadcast_epi32(
+                    &lut_lin[src0[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                b0 = _xmm_broadcast_epi32(
+                    &lut_lin[src0[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
 
                 r1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize()),
+                    &lut_lin[src0[src_cn.r_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 g1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize()),
+                    &lut_lin[src0[src_cn.g_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 b1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize()),
+                    &lut_lin[src0[src_cn.b_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
 
                 a0 = if src_channels == 4 {
@@ -171,18 +171,24 @@ where
 
                 _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
 
-                r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                b0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
+                r0 = _xmm_broadcast_epi32(
+                    &lut_lin[src[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                g0 = _xmm_broadcast_epi32(
+                    &lut_lin[src[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                b0 = _xmm_broadcast_epi32(
+                    &lut_lin[src[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
 
                 r1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src[src_cn.r_i() + src_channels]._as_usize()),
+                    &lut_lin[src[src_cn.r_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 g1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src[src_cn.g_i() + src_channels]._as_usize()),
+                    &lut_lin[src[src_cn.g_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 b1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src[src_cn.b_i() + src_channels]._as_usize()),
+                    &lut_lin[src[src_cn.b_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
@@ -253,10 +259,15 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let r = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                let mut g =
-                    _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                let b = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
+                let r = _xmm_broadcast_epi32(
+                    &lut_lin[src[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                let mut g = _xmm_broadcast_epi32(
+                    &lut_lin[src[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                let b = _xmm_broadcast_epi32(
+                    &lut_lin[src[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
 
                 g = _mm_slli_epi32::<16>(g);
 
@@ -312,14 +323,6 @@ where
 
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
 
         unsafe {
@@ -343,18 +346,24 @@ where
             let (mut r1, mut g1, mut b1, mut a1);
 
             for dst in in_out.chunks_exact_mut(src_channels * 2) {
-                r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize()));
-                g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize()));
-                b0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize()));
+                r0 = _xmm_broadcast_epi32(
+                    &lut_lin[dst[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                g0 = _xmm_broadcast_epi32(
+                    &lut_lin[dst[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                b0 = _xmm_broadcast_epi32(
+                    &lut_lin[dst[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
 
                 r1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(dst[src_cn.r_i() + src_channels]._as_usize()),
+                    &lut_lin[dst[src_cn.r_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 g1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(dst[src_cn.g_i() + src_channels]._as_usize()),
+                    &lut_lin[dst[src_cn.g_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
                 b1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(dst[src_cn.b_i() + src_channels]._as_usize()),
+                    &lut_lin[dst[src_cn.b_i() + src_channels]._as_usize() & (LINEAR_CAP - 1)],
                 );
 
                 a0 = if src_channels == 4 {
@@ -405,10 +414,15 @@ where
             let dst = in_out.chunks_exact_mut(src_channels * 2).into_remainder();
 
             for dst in dst.chunks_exact_mut(src_channels) {
-                let r = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize()));
-                let mut g =
-                    _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize()));
-                let b = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize()));
+                let r = _xmm_broadcast_epi32(
+                    &lut_lin[dst[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                let mut g = _xmm_broadcast_epi32(
+                    &lut_lin[dst[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
+                let b = _xmm_broadcast_epi32(
+                    &lut_lin[dst[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)],
+                );
 
                 g = _mm_slli_epi32::<16>(g);
 
@@ -449,8 +463,10 @@ impl<
     T: Copy + PointeeSizeExpressible + 'static + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
-> TransformExecutor<T> for TransformShaperRgbQ2_13OptAvx<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+> TransformExecutor<T>
+    for TransformShaperRgbQ2_13OptAvx<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP, PRECISION>
 where
     u32: AsPrimitive<T>,
 {
@@ -467,9 +483,10 @@ impl<
     T: Copy + PointeeSizeExpressible + 'static + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
 > InPlaceTransformExecutor<T>
-    for TransformShaperRgbQ2_13OptAvx<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+    for TransformShaperRgbQ2_13OptAvx<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP, PRECISION>
 where
     u32: AsPrimitive<T>,
 {

--- a/src/conversions/avx/t_lut3_to_3.rs
+++ b/src/conversions/avx/t_lut3_to_3.rs
@@ -83,7 +83,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn AvxMdInterpolation + Send + Sync>,
+        interpolator: Box<dyn AvxMdInterpolation<BINS> + Send + Sync>,
     ) {
         let src_cn = Layout::from(SRC_LAYOUT);
         let src_channels = src_cn.channels();
@@ -114,13 +114,7 @@ where
                 max_value
             };
 
-            let v = interpolator.inter3_sse(
-                &self.lut,
-                x.as_(),
-                y.as_(),
-                z.as_(),
-                self.weights.as_slice(),
-            );
+            let v = interpolator.inter3_sse(&self.lut, x.as_(), y.as_(), z.as_(), &self.weights);
             if T::FINITE {
                 let mut r = _mm_mul_ps(v.v, value_scale);
                 r = _mm_max_ps(r, _mm_setzero_ps());

--- a/src/conversions/avx/t_lut3_to_3_q0_15.rs
+++ b/src/conversions/avx/t_lut3_to_3_q0_15.rs
@@ -85,7 +85,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn AvxMdInterpolationQ0_15 + Send + Sync>,
+        interpolator: Box<dyn AvxMdInterpolationQ0_15<BINS> + Send + Sync>,
     ) {
         let src_cn = Layout::from(SRC_LAYOUT);
         let src_channels = src_cn.channels();
@@ -121,13 +121,7 @@ where
                 max_value
             };
 
-            let v = interpolator.inter3_sse(
-                &self.lut,
-                x.as_(),
-                y.as_(),
-                z.as_(),
-                self.weights.as_slice(),
-            );
+            let v = interpolator.inter3_sse(&self.lut, x.as_(), y.as_(), z.as_(), &self.weights);
             if T::FINITE {
                 let mut o = _mm_max_epi16(v.v, _mm_setzero_si128());
                 o = _mm_min_epi16(o, v_max_scale);

--- a/src/conversions/neon/interpolator.rs
+++ b/src/conversions/neon/interpolator.rs
@@ -231,18 +231,18 @@ impl<const GRID_SIZE: usize> Fetcher<NeonVectorDouble>
     }
 }
 
-pub(crate) trait NeonMdInterpolation {
+pub(crate) trait NeonMdInterpolation<const BINS: usize> {
     fn inter3_neon(
         &self,
         cube: &[NeonAlignedF32],
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
     ) -> NeonVector;
 }
 
-pub(crate) trait NeonMdInterpolationDouble {
+pub(crate) trait NeonMdInterpolationDouble<const BINS: usize> {
     fn inter3_neon(
         &self,
         table0: &[NeonAlignedF32],
@@ -250,23 +250,23 @@ pub(crate) trait NeonMdInterpolationDouble {
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
     ) -> (NeonVector, NeonVector);
 }
 
 impl<const GRID_SIZE: usize> TetrahedralNeon<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<NeonVector>,
     ) -> NeonVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -326,17 +326,17 @@ impl<const GRID_SIZE: usize> TetrahedralNeon<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TetrahedralNeonDouble<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<NeonVectorDouble>,
     ) -> (NeonVector, NeonVector) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -396,14 +396,16 @@ impl<const GRID_SIZE: usize> TetrahedralNeonDouble<GRID_SIZE> {
 
 macro_rules! define_md_inter_neon {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> NeonMdInterpolation for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> NeonMdInterpolation<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_neon(
                 &self,
                 cube: &[NeonAlignedF32],
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<f32>],
+                lut: &[BarycentricWeight<f32>; BINS],
             ) -> NeonVector {
                 self.interpolate(
                     in_r,
@@ -419,7 +421,9 @@ macro_rules! define_md_inter_neon {
 
 macro_rules! define_md_inter_neon_d {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> NeonMdInterpolationDouble for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> NeonMdInterpolationDouble<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_neon(
                 &self,
                 table0: &[NeonAlignedF32],
@@ -427,7 +431,7 @@ macro_rules! define_md_inter_neon_d {
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<f32>],
+                lut: &[BarycentricWeight<f32>; BINS],
             ) -> (NeonVector, NeonVector) {
                 self.interpolate(
                     in_r,
@@ -455,17 +459,17 @@ define_md_inter_neon_d!(TrilinearNeonDouble);
 
 impl<const GRID_SIZE: usize> PyramidalNeon<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<NeonVector>,
     ) -> NeonVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -532,17 +536,17 @@ impl<const GRID_SIZE: usize> PyramidalNeon<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> PyramidalNeonDouble<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<NeonVectorDouble>,
     ) -> (NeonVector, NeonVector) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -619,17 +623,17 @@ impl<const GRID_SIZE: usize> PyramidalNeonDouble<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> PrismaticNeon<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<NeonVector>,
     ) -> NeonVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -687,17 +691,17 @@ impl<const GRID_SIZE: usize> PrismaticNeon<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> PrismaticNeonDouble<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         rv: impl Fetcher<NeonVectorDouble>,
     ) -> (NeonVector, NeonVector) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -761,17 +765,17 @@ impl<const GRID_SIZE: usize> PrismaticNeonDouble<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearNeonDouble<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<NeonVectorDouble>,
     ) -> (NeonVector, NeonVector) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -818,17 +822,17 @@ impl<const GRID_SIZE: usize> TrilinearNeonDouble<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearNeon<GRID_SIZE> {
     #[inline]
-    fn interpolate(
+    fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<NeonVector>,
     ) -> NeonVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;

--- a/src/conversions/neon/interpolator_q0_15.rs
+++ b/src/conversions/neon/interpolator_q0_15.rs
@@ -246,18 +246,18 @@ impl<const GRID_SIZE: usize> Fetcher<NeonVectorQ0_15Double>
     }
 }
 
-pub(crate) trait NeonMdInterpolationQ0_15 {
+pub(crate) trait NeonMdInterpolationQ0_15<const BINS: usize> {
     fn inter3_neon(
         &self,
         cube: &[NeonAlignedI16x4],
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
     ) -> NeonVectorQ0_15;
 }
 
-pub(crate) trait NeonMdInterpolationQ0_15Double {
+pub(crate) trait NeonMdInterpolationQ0_15Double<const BINS: usize> {
     fn inter3_neon(
         &self,
         table0: &[NeonAlignedI16x4],
@@ -265,24 +265,24 @@ pub(crate) trait NeonMdInterpolationQ0_15Double {
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
     ) -> (NeonVectorQ0_15, NeonVectorQ0_15);
 }
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralNeonQ0_15<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<NeonVectorQ0_15>,
     ) -> NeonVectorQ0_15 {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -343,17 +343,17 @@ impl<const GRID_SIZE: usize> TetrahedralNeonQ0_15<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralNeonQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<NeonVectorQ0_15Double>,
     ) -> (NeonVectorQ0_15, NeonVectorQ0_15) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -413,14 +413,16 @@ impl<const GRID_SIZE: usize> TetrahedralNeonQ0_15Double<GRID_SIZE> {
 
 macro_rules! define_md_inter_neon {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> NeonMdInterpolationQ0_15 for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> NeonMdInterpolationQ0_15<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_neon(
                 &self,
                 cube: &[NeonAlignedI16x4],
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<i16>],
+                lut: &[BarycentricWeight<i16>; BINS],
             ) -> NeonVectorQ0_15 {
                 unsafe {
                     self.interpolate(
@@ -438,7 +440,9 @@ macro_rules! define_md_inter_neon {
 
 macro_rules! define_md_inter_neon_d {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> NeonMdInterpolationQ0_15Double for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> NeonMdInterpolationQ0_15Double<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_neon(
                 &self,
                 table0: &[NeonAlignedI16x4],
@@ -446,7 +450,7 @@ macro_rules! define_md_inter_neon_d {
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<i16>],
+                lut: &[BarycentricWeight<i16>; BINS],
             ) -> (NeonVectorQ0_15, NeonVectorQ0_15) {
                 unsafe {
                     self.interpolate(
@@ -483,17 +487,17 @@ define_md_inter_neon_d!(TrilinearNeonQ0_15Double);
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalNeonQ0_15<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<NeonVectorQ0_15>,
     ) -> NeonVectorQ0_15 {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -571,17 +575,17 @@ impl<const GRID_SIZE: usize> PyramidalNeonQ0_15<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalNeonQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<NeonVectorQ0_15Double>,
     ) -> (NeonVectorQ0_15, NeonVectorQ0_15) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -656,17 +660,17 @@ impl<const GRID_SIZE: usize> PyramidalNeonQ0_15Double<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticNeonQ0_15<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<NeonVectorQ0_15>,
     ) -> NeonVectorQ0_15 {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -733,17 +737,17 @@ impl<const GRID_SIZE: usize> PrismaticNeonQ0_15<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticNeonQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         rv: impl Fetcher<NeonVectorQ0_15Double>,
     ) -> (NeonVectorQ0_15, NeonVectorQ0_15) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -807,17 +811,17 @@ impl<const GRID_SIZE: usize> PrismaticNeonQ0_15Double<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearNeonQ0_15Double<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<NeonVectorQ0_15Double>,
     ) -> (NeonVectorQ0_15, NeonVectorQ0_15) {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -864,17 +868,17 @@ impl<const GRID_SIZE: usize> TrilinearNeonQ0_15Double<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearNeonQ0_15<GRID_SIZE> {
     #[target_feature(enable = "rdm")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<NeonVectorQ0_15>,
     ) -> NeonVectorQ0_15 {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;

--- a/src/conversions/neon/lut4_to_3.rs
+++ b/src/conversions/neon/lut4_to_3.rs
@@ -82,7 +82,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn NeonMdInterpolationDouble + Send + Sync>,
+        interpolator: Box<dyn NeonMdInterpolationDouble<BINS> + Send + Sync>,
     ) {
         let cn = Layout::from(LAYOUT);
         let channels = cn.channels();
@@ -120,14 +120,8 @@ where
             let table1 = &self.lut[(w * grid_size3) as usize..];
             let table2 = &self.lut[(w_n * grid_size3) as usize..];
 
-            let (a0, b0) = interpolator.inter3_neon(
-                table1,
-                table2,
-                c.as_(),
-                m.as_(),
-                y.as_(),
-                self.weights.as_slice(),
-            );
+            let (a0, b0) =
+                interpolator.inter3_neon(table1, table2, c.as_(), m.as_(), y.as_(), &self.weights);
             let (a0, b0) = (a0.v, b0.v);
 
             if T::FINITE {

--- a/src/conversions/neon/lut4_to_3_q0_15.rs
+++ b/src/conversions/neon/lut4_to_3_q0_15.rs
@@ -74,7 +74,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn NeonMdInterpolationQ0_15Double + Send + Sync>,
+        interpolator: Box<dyn NeonMdInterpolationQ0_15Double<BINS> + Send + Sync>,
     ) {
         let cn = Layout::from(LAYOUT);
         let channels = cn.channels();
@@ -117,14 +117,8 @@ where
             let table1 = &self.lut[(w * grid_size3) as usize..];
             let table2 = &self.lut[(w_n * grid_size3) as usize..];
 
-            let (a0, b0) = interpolator.inter3_neon(
-                table1,
-                table2,
-                c.as_(),
-                m.as_(),
-                y.as_(),
-                self.weights.as_slice(),
-            );
+            let (a0, b0) =
+                interpolator.inter3_neon(table1, table2, c.as_(), m.as_(), y.as_(), &self.weights);
             let (a0, b0) = (a0.v, b0.v);
 
             let t0 = vdup_n_s16(t);

--- a/src/conversions/neon/rgb_xyz.rs
+++ b/src/conversions/neon/rgb_xyz.rs
@@ -77,21 +77,27 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.r_linear.len() >= cap);
-            assert!(self.profile.g_linear.len() >= cap);
-            assert!(self.profile.b_linear.len() >= cap);
-        } else {
-            assert!(self.profile.r_linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            assert!(self.profile.g_linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            assert!(self.profile.b_linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let r_lin = &self.profile.r_linear;
         let g_lin = &self.profile.g_linear;
         let b_lin = &self.profile.b_linear;
+        let r_mask = r_lin.len() - 1;
+        let g_mask = g_lin.len() - 1;
+        let b_mask = b_lin.len() - 1;
+
+        debug_assert!(r_lin.len().is_power_of_two());
+        debug_assert!(g_lin.len().is_power_of_two());
+        debug_assert!(b_lin.len().is_power_of_two());
+
+        if T::FINITE {
+            let cap = 1usize << self.bit_depth;
+            assert!(r_lin.len() >= cap);
+            assert!(g_lin.len() >= cap);
+            assert!(b_lin.len() >= cap);
+        } else {
+            assert!(r_lin.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+            assert!(g_lin.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+            assert!(b_lin.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+        }
 
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
@@ -121,21 +127,21 @@ where
                     .zip(dst0.chunks_exact_mut(dst_channels * 2))
                     .zip(dst1.chunks_exact_mut(dst_channels * 2))
                 {
-                    let r0p = r_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = g_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = b_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &r_lin[src0[src_cn.r_i()]._as_usize() & r_mask];
+                    let g0p = &g_lin[src0[src_cn.g_i()]._as_usize() & g_mask];
+                    let b0p = &b_lin[src0[src_cn.b_i()]._as_usize() & b_mask];
 
-                    let r1p = r_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = g_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = b_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &r_lin[src0[src_cn.r_i() + src_channels]._as_usize() & r_mask];
+                    let g1p = &g_lin[src0[src_cn.g_i() + src_channels]._as_usize() & g_mask];
+                    let b1p = &b_lin[src0[src_cn.b_i() + src_channels]._as_usize() & b_mask];
 
-                    let r2p = r_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = g_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = b_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &r_lin[src1[src_cn.r_i()]._as_usize() & r_mask];
+                    let g2p = &g_lin[src1[src_cn.g_i()]._as_usize() & g_mask];
+                    let b2p = &b_lin[src1[src_cn.b_i()]._as_usize() & b_mask];
 
-                    let r3p = r_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = g_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = b_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &r_lin[src1[src_cn.r_i() + src_channels]._as_usize() & r_mask];
+                    let g3p = &g_lin[src1[src_cn.g_i() + src_channels]._as_usize() & g_mask];
+                    let b3p = &b_lin[src1[src_cn.b_i() + src_channels]._as_usize() & b_mask];
 
                     r0 = vld1q_dup_f32(r0p);
                     g0 = vld1q_dup_f32(g0p);
@@ -251,9 +257,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = r_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = g_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = b_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &r_lin[src[src_cn.r_i()]._as_usize() & r_mask];
+                let gp = &g_lin[src[src_cn.g_i()]._as_usize() & g_mask];
+                let bp = &b_lin[src[src_cn.b_i()]._as_usize() & b_mask];
                 let r = vld1q_dup_f32(rp);
                 let g = vld1q_dup_f32(gp);
                 let b = vld1q_dup_f32(bp);

--- a/src/conversions/neon/rgb_xyz_opt.rs
+++ b/src/conversions/neon/rgb_xyz_opt.rs
@@ -77,15 +77,15 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        let lin_mask = lut_lin.len() - 1;
+        debug_assert!(lut_lin.len().is_power_of_two());
+
+        if T::FINITE {
+            assert!(lut_lin.len() >= 1usize << self.bit_depth);
+        } else {
+            assert!(lut_lin.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+        }
 
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
@@ -115,21 +115,21 @@ where
                     .zip(dst0.chunks_exact_mut(dst_channels * 2))
                     .zip(dst1.chunks_exact_mut(dst_channels * 2))
                 {
-                    let r0p = lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[src0[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g0p = &lut_lin[src0[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b0p = &lut_lin[src0[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r1p = lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[src0[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g1p = &lut_lin[src0[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b1p = &lut_lin[src0[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
-                    let r2p = lut_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[src1[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g2p = &lut_lin[src1[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b2p = &lut_lin[src1[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r3p = lut_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[src1[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g3p = &lut_lin[src1[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b3p = &lut_lin[src1[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
                     r0 = vld1q_dup_f32(r0p);
                     g0 = vld1q_dup_f32(g0p);
@@ -245,9 +245,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize() & lin_mask];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize() & lin_mask];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize() & lin_mask];
                 let r = vld1q_dup_f32(rp);
                 let g = vld1q_dup_f32(gp);
                 let b = vld1q_dup_f32(bp);

--- a/src/conversions/neon/rgb_xyz_q1_30_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q1_30_opt.rs
@@ -71,9 +71,11 @@ where
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
 
-        // safety precondition for linearization table
+        let lin_mask = self.profile.linear.len() - 1;
+        debug_assert!(self.profile.linear.len().is_power_of_two());
+
         if T::FINITE {
-            assert!(self.profile.linear.len() >= (1 << self.bit_depth) - 1);
+            assert!(self.profile.linear.len() >= 1usize << self.bit_depth);
         } else {
             assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
         }
@@ -103,21 +105,21 @@ where
                     .zip(dst0.chunks_exact_mut(dst_channels * 2))
                     .zip(dst1.chunks_exact_mut(dst_channels * 2))
                 {
-                    let r0p = lin_lut.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lin_lut.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lin_lut.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lin_lut[src0[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g0p = &lin_lut[src0[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b0p = &lin_lut[src0[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r1p = lin_lut.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lin_lut.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lin_lut.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lin_lut[src0[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g1p = &lin_lut[src0[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b1p = &lin_lut[src0[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
-                    let r2p = lin_lut.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lin_lut.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lin_lut.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lin_lut[src1[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g2p = &lin_lut[src1[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b2p = &lin_lut[src1[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r3p = lin_lut.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lin_lut.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lin_lut.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lin_lut[src1[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g3p = &lin_lut[src1[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b3p = &lin_lut[src1[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
                     r0 = vld1q_dup_s32(r0p);
                     g0 = vld1q_dup_s32(g0p);
@@ -224,9 +226,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = lin_lut.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lin_lut.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lin_lut.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lin_lut[src[src_cn.r_i()]._as_usize() & lin_mask];
+                let gp = &lin_lut[src[src_cn.g_i()]._as_usize() & lin_mask];
+                let bp = &lin_lut[src[src_cn.b_i()]._as_usize() & lin_mask];
                 let r = vld1q_dup_s32(rp);
                 let g = vld1q_dup_s32(gp);
                 let b = vld1q_dup_s32(bp);

--- a/src/conversions/neon/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q2_13_opt.rs
@@ -73,15 +73,15 @@ where
         let t = self.profile.adaptation_matrix.transpose();
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        let lin_mask = lut_lin.len() - 1;
+        debug_assert!(lut_lin.len().is_power_of_two());
+
+        if T::FINITE {
+            assert!(lut_lin.len() >= 1usize << self.bit_depth);
+        } else {
+            assert!(lut_lin.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+        }
 
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
@@ -107,21 +107,21 @@ where
                 let (mut r3, mut g3, mut b3, mut a3);
 
                 if let (Some(src0), Some(src1)) = (src_iter0.next(), src_iter1.next()) {
-                    let r0p = lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[src0[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g0p = &lut_lin[src0[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b0p = &lut_lin[src0[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r1p = lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[src0[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g1p = &lut_lin[src0[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b1p = &lut_lin[src0[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
-                    let r2p = lut_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[src1[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g2p = &lut_lin[src1[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b2p = &lut_lin[src1[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r3p = lut_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[src1[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g3p = &lut_lin[src1[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b3p = &lut_lin[src1[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
                     r0 = vld1_dup_s16(r0p);
                     g0 = vld1_dup_s16(g0p);
@@ -211,21 +211,21 @@ where
                     vr2 = vmin_u16(vr2, v_max_value);
                     vr3 = vmin_u16(vr3, v_max_value);
 
-                    let r0p = lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[src0[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g0p = &lut_lin[src0[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b0p = &lut_lin[src0[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r1p = lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[src0[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g1p = &lut_lin[src0[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b1p = &lut_lin[src0[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
-                    let r2p = lut_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[src1[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g2p = &lut_lin[src1[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b2p = &lut_lin[src1[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r3p = lut_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[src1[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g3p = &lut_lin[src1[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b3p = &lut_lin[src1[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
                     r0 = vld1_dup_s16(r0p);
                     g0 = vld1_dup_s16(g0p);
@@ -371,9 +371,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize() & lin_mask];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize() & lin_mask];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize() & lin_mask];
                 let r = vld1_dup_s16(rp);
                 let g = vld1_dup_s16(gp);
                 let b = vld1_dup_s16(bp);
@@ -431,15 +431,15 @@ where
         let t = self.profile.adaptation_matrix.transpose();
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        let lin_mask = lut_lin.len() - 1;
+        debug_assert!(lut_lin.len().is_power_of_two());
+
+        if T::FINITE {
+            assert!(lut_lin.len() >= 1usize << self.bit_depth);
+        } else {
+            assert!(lut_lin.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
+        }
 
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, src_channels);
 
@@ -463,21 +463,21 @@ where
                     .chunks_exact_mut(src_channels * 2)
                     .zip(dst1.chunks_exact_mut(src_channels * 2))
                 {
-                    let r0p = lut_lin.get_unchecked(dst0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(dst0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(dst0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[dst0[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g0p = &lut_lin[dst0[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b0p = &lut_lin[dst0[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r1p = lut_lin.get_unchecked(dst0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(dst0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(dst0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[dst0[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g1p = &lut_lin[dst0[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b1p = &lut_lin[dst0[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
-                    let r2p = lut_lin.get_unchecked(dst1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(dst1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(dst1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[dst1[src_cn.r_i()]._as_usize() & lin_mask];
+                    let g2p = &lut_lin[dst1[src_cn.g_i()]._as_usize() & lin_mask];
+                    let b2p = &lut_lin[dst1[src_cn.b_i()]._as_usize() & lin_mask];
 
-                    let r3p = lut_lin.get_unchecked(dst1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(dst1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(dst1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[dst1[src_cn.r_i() + src_channels]._as_usize() & lin_mask];
+                    let g3p = &lut_lin[dst1[src_cn.g_i() + src_channels]._as_usize() & lin_mask];
+                    let b3p = &lut_lin[dst1[src_cn.b_i() + src_channels]._as_usize() & lin_mask];
 
                     r0 = vld1_dup_s16(r0p);
                     g0 = vld1_dup_s16(g0p);
@@ -581,9 +581,9 @@ where
             }
 
             for dst in dst_remainder.chunks_exact_mut(src_channels) {
-                let rp = lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[dst[src_cn.r_i()]._as_usize() & lin_mask];
+                let gp = &lut_lin[dst[src_cn.g_i()]._as_usize() & lin_mask];
+                let bp = &lut_lin[dst[src_cn.b_i()]._as_usize() & lin_mask];
                 let r = vld1_dup_s16(rp);
                 let g = vld1_dup_s16(gp);
                 let b = vld1_dup_s16(bp);

--- a/src/conversions/neon/t_lut3_to_3.rs
+++ b/src/conversions/neon/t_lut3_to_3.rs
@@ -83,7 +83,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn NeonMdInterpolation + Send + Sync>,
+        interpolator: Box<dyn NeonMdInterpolation<BINS> + Send + Sync>,
     ) {
         unsafe {
             let src_cn = Layout::from(SRC_LAYOUT);
@@ -115,13 +115,8 @@ where
                     max_value
                 };
 
-                let v = interpolator.inter3_neon(
-                    &self.lut,
-                    x.as_(),
-                    y.as_(),
-                    z.as_(),
-                    self.weights.as_slice(),
-                );
+                let v =
+                    interpolator.inter3_neon(&self.lut, x.as_(), y.as_(), z.as_(), &self.weights);
                 if T::FINITE {
                     let mut r = vfmaq_f32(vdupq_n_f32(0.5f32), v.v, value_scale);
                     r = vminq_f32(r, value_scale);

--- a/src/conversions/neon/t_lut3_to_3_q0_15.rs
+++ b/src/conversions/neon/t_lut3_to_3_q0_15.rs
@@ -86,7 +86,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn NeonMdInterpolationQ0_15 + Send + Sync>,
+        interpolator: Box<dyn NeonMdInterpolationQ0_15<BINS> + Send + Sync>,
     ) {
         let src_cn = Layout::from(SRC_LAYOUT);
         let src_channels = src_cn.channels();
@@ -122,13 +122,7 @@ where
                 max_value
             };
 
-            let v = interpolator.inter3_neon(
-                &self.lut,
-                x.as_(),
-                y.as_(),
-                z.as_(),
-                self.weights.as_slice(),
-            );
+            let v = interpolator.inter3_neon(&self.lut, x.as_(), y.as_(), z.as_(), &self.weights);
             if T::FINITE {
                 let mut o = vmax_s16(v.v, vdup_n_s16(0));
                 o = vmin_s16(o, v_max_scale);

--- a/src/conversions/rgbxyz.rs
+++ b/src/conversions/rgbxyz.rs
@@ -491,6 +491,55 @@ macro_rules! create_in_place_opt_rgb_xyz_fp_to_v {
     };
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[allow(unused)]
+macro_rules! create_in_place_opt_rgb_xyz_fp {
+    ($dep_name: ident, $dependant: ident, $resolution: ident, $shaper: ident) => {
+        pub(crate) fn $dep_name<
+            T: Clone + Send + Sync + Default + PointeeSizeExpressible + Copy + 'static,
+            const LINEAR_CAP: usize,
+            const PRECISION: i32,
+        >(
+            layout: Layout,
+            profile: $shaper<T, LINEAR_CAP>,
+            gamma_lut: usize,
+            bit_depth: usize,
+        ) -> Result<Arc<dyn InPlaceTransformExecutor<T> + Send + Sync>, CmsError>
+        where
+            u32: AsPrimitive<T>,
+        {
+            let q2_13_profile =
+                profile.to_q2_13_n::<$resolution, PRECISION, LINEAR_CAP>(gamma_lut, bit_depth);
+            if layout == Layout::Rgba {
+                return Ok(Arc::new($dependant::<
+                    T,
+                    { Layout::Rgba as u8 },
+                    { Layout::Rgba as u8 },
+                    LINEAR_CAP,
+                    PRECISION,
+                > {
+                    profile: q2_13_profile,
+                    bit_depth,
+                    gamma_lut,
+                }));
+            } else if layout == Layout::Rgb {
+                return Ok(Arc::new($dependant::<
+                    T,
+                    { Layout::Rgb as u8 },
+                    { Layout::Rgb as u8 },
+                    LINEAR_CAP,
+                    PRECISION,
+                > {
+                    profile: q2_13_profile,
+                    bit_depth,
+                    gamma_lut,
+                }));
+            }
+            Err(CmsError::UnsupportedProfileConnection)
+        }
+    };
+}
+
 #[allow(unused)]
 macro_rules! create_in_place_rgb_xyz {
     ($dep_name: ident, $dependant: ident, $shaper: ident) => {
@@ -565,7 +614,7 @@ create_rgb_xyz_dependant_executor!(
     any(target_arch = "x86", target_arch = "x86_64"),
     feature = "sse_shaper_optimized_paths"
 ))]
-create_rgb_xyz_dependant_executor_to_v!(
+create_rgb_xyz_dependant_executor!(
     make_rgb_xyz_rgb_transform_sse_41_opt,
     TransformShaperRgbOptSse,
     TransformMatrixShaperOptimized
@@ -579,7 +628,7 @@ create_rgb_xyz_dependant_executor!(
 );
 
 #[cfg(all(target_arch = "x86_64", feature = "avx_shaper_optimized_paths"))]
-create_rgb_xyz_dependant_executor_to_v!(
+create_rgb_xyz_dependant_executor!(
     make_rgb_xyz_rgb_transform_avx2_opt,
     TransformShaperRgbOptAvx,
     TransformMatrixShaperOptimized
@@ -827,7 +876,7 @@ use crate::conversions::sse::TransformShaperQ2_13OptSse;
     feature = "in_place",
     feature = "sse_shaper_fixed_point_paths"
 ))]
-create_in_place_opt_rgb_xyz_fp_to_v!(
+create_in_place_opt_rgb_xyz_fp!(
     make_sse_rgb_xyz_in_place_transform_q2_13_opt,
     TransformShaperQ2_13OptSse,
     i32,
@@ -846,7 +895,7 @@ use crate::conversions::avx::TransformShaperRgbQ2_13OptAvx;
     feature = "in_place",
     feature = "avx_shaper_fixed_point_paths"
 ))]
-create_in_place_opt_rgb_xyz_fp_to_v!(
+create_in_place_opt_rgb_xyz_fp!(
     make_avx_rgb_xyz_in_place_transform_q2_13_opt,
     TransformShaperRgbQ2_13OptAvx,
     i32,

--- a/src/conversions/rgbxyz_fixed.rs
+++ b/src/conversions/rgbxyz_fixed.rs
@@ -397,7 +397,7 @@ use crate::conversions::sse::TransformShaperQ2_13OptSse;
     any(target_arch = "x86", target_arch = "x86_64"),
     feature = "sse_shaper_fixed_point_paths"
 ))]
-create_rgb_xyz_dependant_q2_13_executor_fp!(
+create_rgb_xyz_dependant_q2_13_executor!(
     make_rgb_xyz_q2_13_transform_sse_41_opt,
     TransformShaperQ2_13OptSse,
     i32,
@@ -410,7 +410,7 @@ use crate::conversions::rgbxyz::TransformMatrixShaperOptimized;
 use crate::transform::PointeeSizeExpressible;
 
 #[cfg(all(target_arch = "x86_64", feature = "avx_shaper_fixed_point_paths"))]
-create_rgb_xyz_dependant_q2_13_executor_fp!(
+create_rgb_xyz_dependant_q2_13_executor!(
     make_rgb_xyz_q2_13_transform_avx2_opt,
     TransformShaperRgbQ2_13OptAvx,
     i32,

--- a/src/conversions/sse/interpolator.rs
+++ b/src/conversions/sse/interpolator.rs
@@ -126,31 +126,31 @@ impl<const GRID_SIZE: usize> Fetcher<SseVector> for TetrahedralSseFetchVector<'_
     }
 }
 
-pub(crate) trait SseMdInterpolation {
+pub(crate) trait SseMdInterpolation<const BINS: usize> {
     fn inter3_sse(
         &self,
         table: &[SseAlignedF32],
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
     ) -> SseVector;
 }
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralSse<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -210,14 +210,16 @@ impl<const GRID_SIZE: usize> TetrahedralSse<GRID_SIZE> {
 
 macro_rules! define_inter_sse {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> SseMdInterpolation for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> SseMdInterpolation<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_sse(
                 &self,
                 table: &[SseAlignedF32],
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<f32>],
+                lut: &[BarycentricWeight<f32>; BINS],
             ) -> SseVector {
                 unsafe {
                     self.interpolate(
@@ -244,17 +246,17 @@ define_inter_sse!(TrilinearSse);
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalSse<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -322,17 +324,17 @@ impl<const GRID_SIZE: usize> PyramidalSse<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticSse<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -390,17 +392,17 @@ impl<const GRID_SIZE: usize> PrismaticSse<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearSse<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<f32>],
+        lut: &[BarycentricWeight<f32>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;

--- a/src/conversions/sse/interpolator_q0_15.rs
+++ b/src/conversions/sse/interpolator_q0_15.rs
@@ -126,31 +126,31 @@ impl<const GRID_SIZE: usize> Fetcher<SseVector> for TetrahedralSseQ0_15FetchVect
     }
 }
 
-pub(crate) trait SseMdInterpolationQ0_15 {
+pub(crate) trait SseMdInterpolationQ0_15<const BINS: usize> {
     fn inter3_sse(
         &self,
         cube: &[SseAlignedI16x4],
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
     ) -> SseVector;
 }
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralSseQ0_15<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -210,14 +210,16 @@ impl<const GRID_SIZE: usize> TetrahedralSseQ0_15<GRID_SIZE> {
 
 macro_rules! define_inter_sse {
     ($interpolator: ident) => {
-        impl<const GRID_SIZE: usize> SseMdInterpolationQ0_15 for $interpolator<GRID_SIZE> {
+        impl<const GRID_SIZE: usize, const BINS: usize> SseMdInterpolationQ0_15<BINS>
+            for $interpolator<GRID_SIZE>
+        {
             fn inter3_sse(
                 &self,
                 table: &[SseAlignedI16x4],
                 in_r: usize,
                 in_g: usize,
                 in_b: usize,
-                lut: &[BarycentricWeight<i16>],
+                lut: &[BarycentricWeight<i16>; BINS],
             ) -> SseVector {
                 unsafe {
                     self.interpolate(
@@ -244,17 +246,17 @@ define_inter_sse!(TrilinearSseQ0_15);
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalSseQ0_15<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -322,17 +324,17 @@ impl<const GRID_SIZE: usize> PyramidalSseQ0_15<GRID_SIZE> {
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticSseQ0_15<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;
@@ -390,17 +392,17 @@ impl<const GRID_SIZE: usize> PrismaticSseQ0_15<GRID_SIZE> {
 
 impl<const GRID_SIZE: usize> TrilinearSseQ0_15<GRID_SIZE> {
     #[target_feature(enable = "sse4.1")]
-    unsafe fn interpolate(
+    unsafe fn interpolate<const BINS: usize>(
         &self,
         in_r: usize,
         in_g: usize,
         in_b: usize,
-        lut: &[BarycentricWeight<i16>],
+        lut: &[BarycentricWeight<i16>; BINS],
         r: impl Fetcher<SseVector>,
     ) -> SseVector {
-        let lut_r = unsafe { *lut.get_unchecked(in_r) };
-        let lut_g = unsafe { *lut.get_unchecked(in_g) };
-        let lut_b = unsafe { *lut.get_unchecked(in_b) };
+        let lut_r = lut[in_r & (BINS - 1)];
+        let lut_g = lut[in_g & (BINS - 1)];
+        let lut_b = lut[in_b & (BINS - 1)];
 
         let x: i32 = lut_r.x;
         let y: i32 = lut_g.x;

--- a/src/conversions/sse/lut4_to_3.rs
+++ b/src/conversions/sse/lut4_to_3.rs
@@ -84,7 +84,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn SseMdInterpolation + Send + Sync>,
+        interpolator: Box<dyn SseMdInterpolation<BINS> + Send + Sync>,
     ) {
         let cn = Layout::from(LAYOUT);
         let channels = cn.channels();
@@ -123,10 +123,10 @@ where
             let table2 = &self.lut[(w_n * grid_size3) as usize..];
 
             let a0 = interpolator
-                .inter3_sse(table1, c.as_(), m.as_(), y.as_(), self.weights.as_slice())
+                .inter3_sse(table1, c.as_(), m.as_(), y.as_(), &self.weights)
                 .v;
             let b0 = interpolator
-                .inter3_sse(table2, c.as_(), m.as_(), y.as_(), self.weights.as_slice())
+                .inter3_sse(table2, c.as_(), m.as_(), y.as_(), &self.weights)
                 .v;
 
             if T::FINITE {

--- a/src/conversions/sse/lut4_to_3_q0_15.rs
+++ b/src/conversions/sse/lut4_to_3_q0_15.rs
@@ -76,7 +76,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn SseMdInterpolationQ0_15 + Send + Sync>,
+        interpolator: Box<dyn SseMdInterpolationQ0_15<BINS> + Send + Sync>,
     ) {
         let cn = Layout::from(LAYOUT);
         let channels = cn.channels();
@@ -122,10 +122,10 @@ where
             let table2 = &self.lut[(w_n * grid_size3) as usize..];
 
             let a0 = interpolator
-                .inter3_sse(table1, c.as_(), m.as_(), y.as_(), self.weights.as_slice())
+                .inter3_sse(table1, c.as_(), m.as_(), y.as_(), &self.weights)
                 .v;
             let b0 = interpolator
-                .inter3_sse(table2, c.as_(), m.as_(), y.as_(), self.weights.as_slice())
+                .inter3_sse(table2, c.as_(), m.as_(), y.as_(), &self.weights)
                 .v;
 
             let hp = _mm_mulhrs_epi16(_mm_set1_epi16(t_n), a0);

--- a/src/conversions/sse/rgb_xyz_opt.rs
+++ b/src/conversions/sse/rgb_xyz_opt.rs
@@ -27,7 +27,7 @@
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #![cfg(feature = "sse_shaper_optimized_paths")]
-use crate::conversions::rgbxyz::TransformMatrixShaperOptimizedV;
+use crate::conversions::TransformMatrixShaperOptimized;
 use crate::conversions::sse::SseAlignedU16;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
@@ -41,8 +41,9 @@ pub(crate) struct TransformShaperRgbOptSse<
     T: Clone + Copy + 'static + PointeeSizeExpressible + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
 > {
-    pub(crate) profile: TransformMatrixShaperOptimizedV<T>,
+    pub(crate) profile: TransformMatrixShaperOptimized<T, LINEAR_CAP>,
     pub(crate) bit_depth: usize,
     pub(crate) gamma_lut: usize,
 }
@@ -51,7 +52,8 @@ impl<
     T: Clone + Copy + 'static + PointeeSizeExpressible + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
-> TransformShaperRgbOptSse<T, SRC_LAYOUT, DST_LAYOUT>
+    const LINEAR_CAP: usize,
+> TransformShaperRgbOptSse<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP>
 where
     u32: AsPrimitive<T>,
 {
@@ -79,14 +81,6 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
 
         unsafe {
@@ -102,9 +96,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)];
 
                 let mut r = _mm_load_ss(rp);
                 let mut g = _mm_load_ss(gp);
@@ -148,7 +142,8 @@ impl<
     T: Clone + Copy + 'static + PointeeSizeExpressible + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
-> TransformExecutor<T> for TransformShaperRgbOptSse<T, SRC_LAYOUT, DST_LAYOUT>
+    const LINEAR_CAP: usize,
+> TransformExecutor<T> for TransformShaperRgbOptSse<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP>
 where
     u32: AsPrimitive<T>,
 {

--- a/src/conversions/sse/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/sse/rgb_xyz_q2_13_opt.rs
@@ -27,7 +27,7 @@
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #![cfg(feature = "sse_shaper_fixed_point_paths")]
-use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
+use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFixedPointOpt;
 use crate::conversions::sse::SseAlignedU16;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
@@ -48,9 +48,10 @@ pub(crate) struct TransformShaperQ2_13OptSse<
     T: Copy,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
 > {
-    pub(crate) profile: TransformMatrixShaperFpOptVec<i32, i16, T>,
+    pub(crate) profile: TransformMatrixShaperFixedPointOpt<i32, i16, T, LINEAR_CAP>,
     pub(crate) bit_depth: usize,
     pub(crate) gamma_lut: usize,
 }
@@ -59,8 +60,9 @@ impl<
     T: Copy + PointeeSizeExpressible + 'static,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
-> TransformShaperQ2_13OptSse<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+> TransformShaperQ2_13OptSse<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP, PRECISION>
 where
     u32: AsPrimitive<T>,
 {
@@ -98,23 +100,15 @@ where
 
             let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
 
-            // safety precondition for linearization table
-            if T::FINITE {
-                let cap = (1 << self.bit_depth) - 1;
-                assert!(self.profile.linear.len() >= cap);
-            } else {
-                assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            }
-
             let lut_lin = &self.profile.linear;
 
             for (src, dst) in src
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)];
 
                 let mut r = _xmm_load_epi32(rp);
                 let mut g = _xmm_load_epi32(gp);
@@ -189,20 +183,12 @@ where
 
             let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
 
-            // safety precondition for linearization table
-            if T::FINITE {
-                let cap = (1 << self.bit_depth) - 1;
-                assert!(self.profile.linear.len() >= cap);
-            } else {
-                assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            }
-
             let lut_lin = &self.profile.linear;
 
             for dst in in_out.chunks_exact_mut(src_channels) {
-                let rp = lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[dst[src_cn.r_i()]._as_usize() & (LINEAR_CAP - 1)];
+                let gp = &lut_lin[dst[src_cn.g_i()]._as_usize() & (LINEAR_CAP - 1)];
+                let bp = &lut_lin[dst[src_cn.b_i()]._as_usize() & (LINEAR_CAP - 1)];
 
                 let mut r = _xmm_load_epi32(rp);
                 let mut g = _xmm_load_epi32(gp);
@@ -250,8 +236,10 @@ impl<
     T: Copy + PointeeSizeExpressible + 'static + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
-> TransformExecutor<T> for TransformShaperQ2_13OptSse<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+> TransformExecutor<T>
+    for TransformShaperQ2_13OptSse<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP, PRECISION>
 where
     u32: AsPrimitive<T>,
 {
@@ -268,8 +256,10 @@ impl<
     T: Copy + PointeeSizeExpressible + 'static + Default,
     const SRC_LAYOUT: u8,
     const DST_LAYOUT: u8,
+    const LINEAR_CAP: usize,
     const PRECISION: i32,
-> InPlaceTransformExecutor<T> for TransformShaperQ2_13OptSse<T, SRC_LAYOUT, DST_LAYOUT, PRECISION>
+> InPlaceTransformExecutor<T>
+    for TransformShaperQ2_13OptSse<T, SRC_LAYOUT, DST_LAYOUT, LINEAR_CAP, PRECISION>
 where
     u32: AsPrimitive<T>,
 {

--- a/src/conversions/sse/t_lut3_to_3.rs
+++ b/src/conversions/sse/t_lut3_to_3.rs
@@ -86,7 +86,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn SseMdInterpolation + Send + Sync>,
+        interpolator: Box<dyn SseMdInterpolation<BINS> + Send + Sync>,
     ) {
         let src_cn = Layout::from(SRC_LAYOUT);
         let src_channels = src_cn.channels();
@@ -117,13 +117,7 @@ where
                 max_value
             };
 
-            let v = interpolator.inter3_sse(
-                &self.lut,
-                x.as_(),
-                y.as_(),
-                z.as_(),
-                self.weights.as_slice(),
-            );
+            let v = interpolator.inter3_sse(&self.lut, x.as_(), y.as_(), z.as_(), &self.weights);
             if T::FINITE {
                 let mut r = _mm_mul_ps(v.v, value_scale);
                 r = _mm_max_ps(r, _mm_setzero_ps());

--- a/src/conversions/sse/t_lut3_to_3_q0_15.rs
+++ b/src/conversions/sse/t_lut3_to_3_q0_15.rs
@@ -89,7 +89,7 @@ where
         &self,
         src: &[T],
         dst: &mut [T],
-        interpolator: Box<dyn SseMdInterpolationQ0_15 + Send + Sync>,
+        interpolator: Box<dyn SseMdInterpolationQ0_15<BINS> + Send + Sync>,
     ) {
         let src_cn = Layout::from(SRC_LAYOUT);
         let src_channels = src_cn.channels();
@@ -125,13 +125,7 @@ where
                 max_value
             };
 
-            let v = interpolator.inter3_sse(
-                &self.lut,
-                x.as_(),
-                y.as_(),
-                z.as_(),
-                self.weights.as_slice(),
-            );
+            let v = interpolator.inter3_sse(&self.lut, x.as_(), y.as_(), z.as_(), &self.weights);
             if T::FINITE {
                 let mut o = _mm_max_epi16(v.v, _mm_setzero_si128());
                 o = _mm_min_epi16(o, v_max_scale);


### PR DESCRIPTION
## Summary

- Replaces all `unsafe { get_unchecked(...) }` on barycentric weight LUTs and linearization tables with safe indexing across SSE, AVX, AVX512, and NEON SIMD paths
- Barycentric LUT indexing: `lut[idx & (BINS - 1)]` with compile-time `const BINS: usize` threaded through interpolation traits and methods — LLVM proves `x & (N-1) < N` statically and eliminates both the mask and the bounds check
- x86 SSE/AVX linearization: `lut_lin[idx & (LINEAR_CAP - 1)]` with compile-time `const LINEAR_CAP: usize` threaded through opt/Q2_13 structs (matching what AVX512 and non-opt paths already do), eliminating the Vec erasure in `convert_to_v()`
- NEON linearization: uses `lut_lin[idx & (lut_lin.len() - 1)]` runtime mask with `debug_assert!(is_power_of_two())`
- 14 remaining `get_unchecked` sites are 3D cube fetchers (GRID_SIZE 17/33, not power-of-two)

`cargo asm` verified across all monomorphizations of `transform_impl`, `transform_avx2`, `transform_in_place`, `transform_chunk`, and `interpolate`: **zero `panic_bounds_check`** in any function. The compile-time const generic masks are fully elided by LLVM, producing identical codegen to the original `get_unchecked`.

Post-LTO+strip (`codegen-units=1`) app binary: 3,403,720 bytes (safe) vs 3,406,560 bytes (upstream) — 2.8 KB smaller. Note: this app binary only exercises matrix shaper paths (LUT features not enabled), so the barycentric changes are not reflected in this measurement.

## Benchmarks (criterion, AMD Ryzen 9 7950X)

| Benchmark | Upstream (unsafe) | This PR (safe) | Delta |
|---|---|---|---|
| moxcms: RGB → RGB | 3.307 ms | 3.332 ms | +0.7% (noise) |
| moxcms: RGBA → RGBA | 3.342 ms | 3.304 ms | -1.2% (noise) |
| moxcms: RGB16 → RGB16 | 5.147 ms | 5.113 ms | -0.7% (noise) |

No measurable performance difference — all deltas are within benchmark noise.

## Test plan

- [x] `cargo test --all-features` — 65/65 pass
- [x] `cargo test --no-default-features --features "lut,any_to_any,options,extended_range,in_place"` — 65/65 pass
- [x] `cargo clippy --all-features` — clean
- [x] `cargo asm` verified zero `panic_bounds_check` across all transform/interpolate monomorphizations
- [x] Benchmark: no regression vs upstream
- [x] No public API changes
- [ ] CI (Linux, macOS, Windows)
- [ ] NEON codegen verification on aarch64