### PR TITLE
Remove get_unchecked from linearization table lookups

### DIFF
--- a/src/conversions/avx/rgb_xyz_opt.rs
+++ b/src/conversions/avx/rgb_xyz_opt.rs
@@ -76,15 +76,8 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
         unsafe {
             let m0 = _mm256_setr_ps(
@@ -111,18 +104,12 @@ where
             let (mut r1, mut g1, mut b1, mut a1);
 
             for (src, dst) in src_iter.zip(dst_iter) {
-                r0 = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                g0 = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                b0 = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
-                r1 = _mm_broadcast_ss(
-                    lut_lin.get_unchecked(src[src_cn.r_i() + src_channels]._as_usize()),
-                );
-                g1 = _mm_broadcast_ss(
-                    lut_lin.get_unchecked(src[src_cn.g_i() + src_channels]._as_usize()),
-                );
-                b1 = _mm_broadcast_ss(
-                    lut_lin.get_unchecked(src[src_cn.b_i() + src_channels]._as_usize()),
-                );
+                r0 = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+                g0 = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+                b0 = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize()]);
+                r1 = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i() + src_channels]._as_usize()]);
+                g1 = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i() + src_channels]._as_usize()]);
+                b1 = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i() + src_channels]._as_usize()]);
                 a0 = if src_channels == 4 {
                     src[src_cn.a_i()]
                 } else {
@@ -179,9 +166,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let r = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                let g = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                let b = _mm_broadcast_ss(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
+                let r = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+                let g = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+                let b = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize()]);
                 let a = if src_channels == 4 {
                     src[src_cn.a_i()]
                 } else {

--- a/src/conversions/avx/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13_opt.rs
@@ -83,15 +83,8 @@ where
 
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
         unsafe {
             let m0 = _mm256_setr_epi16(
@@ -116,19 +109,13 @@ where
             let mut src_iter = src.chunks_exact(src_channels * 2);
 
             if let Some(src0) = src_iter.next() {
-                r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize()));
-                g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize()));
-                b0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize()));
+                r0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.r_i()]._as_usize()]);
+                g0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.g_i()]._as_usize()]);
+                b0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.b_i()]._as_usize()]);
 
-                r1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize()),
-                );
-                g1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize()),
-                );
-                b1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize()),
-                );
+                r1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.r_i() + src_channels]._as_usize()]);
+                g1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.g_i() + src_channels]._as_usize()]);
+                b1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.b_i() + src_channels]._as_usize()]);
 
                 a0 = if src_channels == 4 {
                     src0[src_cn.a_i()]
@@ -171,19 +158,13 @@ where
 
                 _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
 
-                r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                b0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
+                r0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+                g0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+                b0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i()]._as_usize()]);
 
-                r1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src[src_cn.r_i() + src_channels]._as_usize()),
-                );
-                g1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src[src_cn.g_i() + src_channels]._as_usize()),
-                );
-                b1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(src[src_cn.b_i() + src_channels]._as_usize()),
-                );
+                r1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i() + src_channels]._as_usize()]);
+                g1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i() + src_channels]._as_usize()]);
+                b1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i() + src_channels]._as_usize()]);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -253,10 +234,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let r = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize()));
-                let mut g =
-                    _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize()));
-                let b = _xmm_broadcast_epi32(lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize()));
+                let r = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+                let mut g = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+                let b = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i()]._as_usize()]);
 
                 g = _mm_slli_epi32::<16>(g);
 
@@ -312,15 +292,8 @@ where
 
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
         unsafe {
             let m0 = _mm256_setr_epi16(
@@ -343,19 +316,13 @@ where
             let (mut r1, mut g1, mut b1, mut a1);
 
             for dst in in_out.chunks_exact_mut(src_channels * 2) {
-                r0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize()));
-                g0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize()));
-                b0 = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize()));
+                r0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i()]._as_usize()]);
+                g0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i()]._as_usize()]);
+                b0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i()]._as_usize()]);
 
-                r1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(dst[src_cn.r_i() + src_channels]._as_usize()),
-                );
-                g1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(dst[src_cn.g_i() + src_channels]._as_usize()),
-                );
-                b1 = _xmm_broadcast_epi32(
-                    lut_lin.get_unchecked(dst[src_cn.b_i() + src_channels]._as_usize()),
-                );
+                r1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i() + src_channels]._as_usize()]);
+                g1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i() + src_channels]._as_usize()]);
+                b1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i() + src_channels]._as_usize()]);
 
                 a0 = if src_channels == 4 {
                     dst[src_cn.a_i()]
@@ -405,10 +372,9 @@ where
             let dst = in_out.chunks_exact_mut(src_channels * 2).into_remainder();
 
             for dst in dst.chunks_exact_mut(src_channels) {
-                let r = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize()));
-                let mut g =
-                    _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize()));
-                let b = _xmm_broadcast_epi32(lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize()));
+                let r = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i()]._as_usize()]);
+                let mut g = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i()]._as_usize()]);
+                let b = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i()]._as_usize()]);
 
                 g = _mm_slli_epi32::<16>(g);
 

--- a/src/conversions/gray2rgb.rs
+++ b/src/conversions/gray2rgb.rs
@@ -492,9 +492,9 @@ mod tests {
                 let transform = gray
                     .create_transform_8bit(src, &srgb, dst, TransformOptions::default())
                     .unwrap();
-                let mut in_px = vec![0u8; src.channels()];
+                let in_px = vec![0u8; src.channels()];
                 let mut out_px = vec![0u8; dst.channels()];
-                transform.transform(&mut in_px, &mut out_px).unwrap();
+                transform.transform(&in_px, &mut out_px).unwrap();
             }
         }
     }

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -26,6 +26,23 @@
  * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+/// Asserts that a linearization LUT is large enough for the pixel type's index range.
+///
+/// For u8, indices are at most 255 so the LUT must have >= 256 entries.
+/// For u16/f32/f64, indices are at most 65535 (f32/f64 clamp through u16) so >= 65536.
+/// When LLVM sees the assertion and knows the index comes from a bounded integer cast,
+/// it can eliminate the subsequent bounds check entirely.
+macro_rules! assert_lut_min_len {
+    ($T:ty, $len:expr) => {
+        if <$T>::IS_U8 {
+            assert!($len >= 256);
+        } else {
+            assert!($len >= 65536);
+        }
+    };
+}
+
 #[cfg(all(target_arch = "x86_64", feature = "avx"))]
 mod avx;
 #[cfg(all(target_arch = "x86_64", feature = "avx512"))]

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -33,6 +33,7 @@
 /// For u16/f32/f64, indices are at most 65535 (f32/f64 clamp through u16) so >= 65536.
 /// When LLVM sees the assertion and knows the index comes from a bounded integer cast,
 /// it can eliminate the subsequent bounds check entirely.
+#[allow(unused_macros)] // only used under feature-gated SIMD modules (avx/sse/neon)
 macro_rules! assert_lut_min_len {
     ($T:ty, $len:expr) => {
         if <$T>::IS_U8 {

--- a/src/conversions/neon/rgb_xyz.rs
+++ b/src/conversions/neon/rgb_xyz.rs
@@ -77,21 +77,12 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.r_linear.len() >= cap);
-            assert!(self.profile.g_linear.len() >= cap);
-            assert!(self.profile.b_linear.len() >= cap);
-        } else {
-            assert!(self.profile.r_linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            assert!(self.profile.g_linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            assert!(self.profile.b_linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let r_lin = &self.profile.r_linear;
         let g_lin = &self.profile.g_linear;
         let b_lin = &self.profile.b_linear;
+        assert_lut_min_len!(T, r_lin.len());
+        assert_lut_min_len!(T, g_lin.len());
+        assert_lut_min_len!(T, b_lin.len());
 
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
@@ -121,21 +112,21 @@ where
                     .zip(dst0.chunks_exact_mut(dst_channels * 2))
                     .zip(dst1.chunks_exact_mut(dst_channels * 2))
                 {
-                    let r0p = r_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = g_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = b_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &r_lin[src0[src_cn.r_i()]._as_usize()];
+                    let g0p = &g_lin[src0[src_cn.g_i()]._as_usize()];
+                    let b0p = &b_lin[src0[src_cn.b_i()]._as_usize()];
 
-                    let r1p = r_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = g_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = b_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &r_lin[src0[src_cn.r_i() + src_channels]._as_usize()];
+                    let g1p = &g_lin[src0[src_cn.g_i() + src_channels]._as_usize()];
+                    let b1p = &b_lin[src0[src_cn.b_i() + src_channels]._as_usize()];
 
-                    let r2p = r_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = g_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = b_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &r_lin[src1[src_cn.r_i()]._as_usize()];
+                    let g2p = &g_lin[src1[src_cn.g_i()]._as_usize()];
+                    let b2p = &b_lin[src1[src_cn.b_i()]._as_usize()];
 
-                    let r3p = r_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = g_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = b_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &r_lin[src1[src_cn.r_i() + src_channels]._as_usize()];
+                    let g3p = &g_lin[src1[src_cn.g_i() + src_channels]._as_usize()];
+                    let b3p = &b_lin[src1[src_cn.b_i() + src_channels]._as_usize()];
 
                     r0 = vld1q_dup_f32(r0p);
                     g0 = vld1q_dup_f32(g0p);
@@ -251,9 +242,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = r_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = g_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = b_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &r_lin[src[src_cn.r_i()]._as_usize()];
+                let gp = &g_lin[src[src_cn.g_i()]._as_usize()];
+                let bp = &b_lin[src[src_cn.b_i()]._as_usize()];
                 let r = vld1q_dup_f32(rp);
                 let g = vld1q_dup_f32(gp);
                 let b = vld1q_dup_f32(bp);

--- a/src/conversions/neon/rgb_xyz_opt.rs
+++ b/src/conversions/neon/rgb_xyz_opt.rs
@@ -77,15 +77,8 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
@@ -115,21 +108,21 @@ where
                     .zip(dst0.chunks_exact_mut(dst_channels * 2))
                     .zip(dst1.chunks_exact_mut(dst_channels * 2))
                 {
-                    let r0p = lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[src0[src_cn.r_i()]._as_usize()];
+                    let g0p = &lut_lin[src0[src_cn.g_i()]._as_usize()];
+                    let b0p = &lut_lin[src0[src_cn.b_i()]._as_usize()];
 
-                    let r1p = lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[src0[src_cn.r_i() + src_channels]._as_usize()];
+                    let g1p = &lut_lin[src0[src_cn.g_i() + src_channels]._as_usize()];
+                    let b1p = &lut_lin[src0[src_cn.b_i() + src_channels]._as_usize()];
 
-                    let r2p = lut_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[src1[src_cn.r_i()]._as_usize()];
+                    let g2p = &lut_lin[src1[src_cn.g_i()]._as_usize()];
+                    let b2p = &lut_lin[src1[src_cn.b_i()]._as_usize()];
 
-                    let r3p = lut_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[src1[src_cn.r_i() + src_channels]._as_usize()];
+                    let g3p = &lut_lin[src1[src_cn.g_i() + src_channels]._as_usize()];
+                    let b3p = &lut_lin[src1[src_cn.b_i() + src_channels]._as_usize()];
 
                     r0 = vld1q_dup_f32(r0p);
                     g0 = vld1q_dup_f32(g0p);
@@ -245,9 +238,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
                 let r = vld1q_dup_f32(rp);
                 let g = vld1q_dup_f32(gp);
                 let b = vld1q_dup_f32(bp);

--- a/src/conversions/neon/rgb_xyz_q1_30_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q1_30_opt.rs
@@ -71,12 +71,7 @@ where
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            assert!(self.profile.linear.len() >= (1 << self.bit_depth) - 1);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
+        assert_lut_min_len!(T, self.profile.linear.len());
 
         unsafe {
             let m0 = vld1q_s32([t.v[0][0], t.v[0][1], t.v[0][2], 0].as_ptr());
@@ -103,21 +98,21 @@ where
                     .zip(dst0.chunks_exact_mut(dst_channels * 2))
                     .zip(dst1.chunks_exact_mut(dst_channels * 2))
                 {
-                    let r0p = lin_lut.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lin_lut.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lin_lut.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lin_lut[src0[src_cn.r_i()]._as_usize()];
+                    let g0p = &lin_lut[src0[src_cn.g_i()]._as_usize()];
+                    let b0p = &lin_lut[src0[src_cn.b_i()]._as_usize()];
 
-                    let r1p = lin_lut.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lin_lut.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lin_lut.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lin_lut[src0[src_cn.r_i() + src_channels]._as_usize()];
+                    let g1p = &lin_lut[src0[src_cn.g_i() + src_channels]._as_usize()];
+                    let b1p = &lin_lut[src0[src_cn.b_i() + src_channels]._as_usize()];
 
-                    let r2p = lin_lut.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lin_lut.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lin_lut.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lin_lut[src1[src_cn.r_i()]._as_usize()];
+                    let g2p = &lin_lut[src1[src_cn.g_i()]._as_usize()];
+                    let b2p = &lin_lut[src1[src_cn.b_i()]._as_usize()];
 
-                    let r3p = lin_lut.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lin_lut.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lin_lut.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lin_lut[src1[src_cn.r_i() + src_channels]._as_usize()];
+                    let g3p = &lin_lut[src1[src_cn.g_i() + src_channels]._as_usize()];
+                    let b3p = &lin_lut[src1[src_cn.b_i() + src_channels]._as_usize()];
 
                     r0 = vld1q_dup_s32(r0p);
                     g0 = vld1q_dup_s32(g0p);
@@ -224,9 +219,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = lin_lut.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lin_lut.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lin_lut.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lin_lut[src[src_cn.r_i()]._as_usize()];
+                let gp = &lin_lut[src[src_cn.g_i()]._as_usize()];
+                let bp = &lin_lut[src[src_cn.b_i()]._as_usize()];
                 let r = vld1q_dup_s32(rp);
                 let g = vld1q_dup_s32(gp);
                 let b = vld1q_dup_s32(bp);

--- a/src/conversions/neon/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q2_13_opt.rs
@@ -73,15 +73,8 @@ where
         let t = self.profile.adaptation_matrix.transpose();
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
         let (src_chunks, src_remainder) = split_by_twos(src, src_channels);
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
@@ -107,21 +100,21 @@ where
                 let (mut r3, mut g3, mut b3, mut a3);
 
                 if let (Some(src0), Some(src1)) = (src_iter0.next(), src_iter1.next()) {
-                    let r0p = lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[src0[src_cn.r_i()]._as_usize()];
+                    let g0p = &lut_lin[src0[src_cn.g_i()]._as_usize()];
+                    let b0p = &lut_lin[src0[src_cn.b_i()]._as_usize()];
 
-                    let r1p = lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[src0[src_cn.r_i() + src_channels]._as_usize()];
+                    let g1p = &lut_lin[src0[src_cn.g_i() + src_channels]._as_usize()];
+                    let b1p = &lut_lin[src0[src_cn.b_i() + src_channels]._as_usize()];
 
-                    let r2p = lut_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[src1[src_cn.r_i()]._as_usize()];
+                    let g2p = &lut_lin[src1[src_cn.g_i()]._as_usize()];
+                    let b2p = &lut_lin[src1[src_cn.b_i()]._as_usize()];
 
-                    let r3p = lut_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[src1[src_cn.r_i() + src_channels]._as_usize()];
+                    let g3p = &lut_lin[src1[src_cn.g_i() + src_channels]._as_usize()];
+                    let b3p = &lut_lin[src1[src_cn.b_i() + src_channels]._as_usize()];
 
                     r0 = vld1_dup_s16(r0p);
                     g0 = vld1_dup_s16(g0p);
@@ -211,21 +204,21 @@ where
                     vr2 = vmin_u16(vr2, v_max_value);
                     vr3 = vmin_u16(vr3, v_max_value);
 
-                    let r0p = lut_lin.get_unchecked(src0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(src0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(src0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[src0[src_cn.r_i()]._as_usize()];
+                    let g0p = &lut_lin[src0[src_cn.g_i()]._as_usize()];
+                    let b0p = &lut_lin[src0[src_cn.b_i()]._as_usize()];
 
-                    let r1p = lut_lin.get_unchecked(src0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(src0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(src0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[src0[src_cn.r_i() + src_channels]._as_usize()];
+                    let g1p = &lut_lin[src0[src_cn.g_i() + src_channels]._as_usize()];
+                    let b1p = &lut_lin[src0[src_cn.b_i() + src_channels]._as_usize()];
 
-                    let r2p = lut_lin.get_unchecked(src1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(src1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(src1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[src1[src_cn.r_i()]._as_usize()];
+                    let g2p = &lut_lin[src1[src_cn.g_i()]._as_usize()];
+                    let b2p = &lut_lin[src1[src_cn.b_i()]._as_usize()];
 
-                    let r3p = lut_lin.get_unchecked(src1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(src1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(src1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[src1[src_cn.r_i() + src_channels]._as_usize()];
+                    let g3p = &lut_lin[src1[src_cn.g_i() + src_channels]._as_usize()];
+                    let b3p = &lut_lin[src1[src_cn.b_i() + src_channels]._as_usize()];
 
                     r0 = vld1_dup_s16(r0p);
                     g0 = vld1_dup_s16(g0p);
@@ -371,9 +364,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst_remainder.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
                 let r = vld1_dup_s16(rp);
                 let g = vld1_dup_s16(gp);
                 let b = vld1_dup_s16(bp);
@@ -431,15 +424,8 @@ where
         let t = self.profile.adaptation_matrix.transpose();
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, src_channels);
 
@@ -463,21 +449,21 @@ where
                     .chunks_exact_mut(src_channels * 2)
                     .zip(dst1.chunks_exact_mut(src_channels * 2))
                 {
-                    let r0p = lut_lin.get_unchecked(dst0[src_cn.r_i()]._as_usize());
-                    let g0p = lut_lin.get_unchecked(dst0[src_cn.g_i()]._as_usize());
-                    let b0p = lut_lin.get_unchecked(dst0[src_cn.b_i()]._as_usize());
+                    let r0p = &lut_lin[dst0[src_cn.r_i()]._as_usize()];
+                    let g0p = &lut_lin[dst0[src_cn.g_i()]._as_usize()];
+                    let b0p = &lut_lin[dst0[src_cn.b_i()]._as_usize()];
 
-                    let r1p = lut_lin.get_unchecked(dst0[src_cn.r_i() + src_channels]._as_usize());
-                    let g1p = lut_lin.get_unchecked(dst0[src_cn.g_i() + src_channels]._as_usize());
-                    let b1p = lut_lin.get_unchecked(dst0[src_cn.b_i() + src_channels]._as_usize());
+                    let r1p = &lut_lin[dst0[src_cn.r_i() + src_channels]._as_usize()];
+                    let g1p = &lut_lin[dst0[src_cn.g_i() + src_channels]._as_usize()];
+                    let b1p = &lut_lin[dst0[src_cn.b_i() + src_channels]._as_usize()];
 
-                    let r2p = lut_lin.get_unchecked(dst1[src_cn.r_i()]._as_usize());
-                    let g2p = lut_lin.get_unchecked(dst1[src_cn.g_i()]._as_usize());
-                    let b2p = lut_lin.get_unchecked(dst1[src_cn.b_i()]._as_usize());
+                    let r2p = &lut_lin[dst1[src_cn.r_i()]._as_usize()];
+                    let g2p = &lut_lin[dst1[src_cn.g_i()]._as_usize()];
+                    let b2p = &lut_lin[dst1[src_cn.b_i()]._as_usize()];
 
-                    let r3p = lut_lin.get_unchecked(dst1[src_cn.r_i() + src_channels]._as_usize());
-                    let g3p = lut_lin.get_unchecked(dst1[src_cn.g_i() + src_channels]._as_usize());
-                    let b3p = lut_lin.get_unchecked(dst1[src_cn.b_i() + src_channels]._as_usize());
+                    let r3p = &lut_lin[dst1[src_cn.r_i() + src_channels]._as_usize()];
+                    let g3p = &lut_lin[dst1[src_cn.g_i() + src_channels]._as_usize()];
+                    let b3p = &lut_lin[dst1[src_cn.b_i() + src_channels]._as_usize()];
 
                     r0 = vld1_dup_s16(r0p);
                     g0 = vld1_dup_s16(g0p);
@@ -581,9 +567,9 @@ where
             }
 
             for dst in dst_remainder.chunks_exact_mut(src_channels) {
-                let rp = lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[dst[src_cn.r_i()]._as_usize()];
+                let gp = &lut_lin[dst[src_cn.g_i()]._as_usize()];
+                let bp = &lut_lin[dst[src_cn.b_i()]._as_usize()];
                 let r = vld1_dup_s16(rp);
                 let g = vld1_dup_s16(gp);
                 let b = vld1_dup_s16(bp);

--- a/src/conversions/sse/rgb_xyz_opt.rs
+++ b/src/conversions/sse/rgb_xyz_opt.rs
@@ -79,15 +79,8 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        // safety precondition for linearization table
-        if T::FINITE {
-            let cap = (1 << self.bit_depth) - 1;
-            assert!(self.profile.linear.len() >= cap);
-        } else {
-            assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-        }
-
         let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
         unsafe {
             let m0 = _mm_setr_ps(t.v[0][0], t.v[0][1], t.v[0][2], 0f32);
@@ -102,9 +95,9 @@ where
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
 
                 let mut r = _mm_load_ss(rp);
                 let mut g = _mm_load_ss(gp);

--- a/src/conversions/sse/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/sse/rgb_xyz_q2_13_opt.rs
@@ -98,23 +98,16 @@ where
 
             let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
 
-            // safety precondition for linearization table
-            if T::FINITE {
-                let cap = (1 << self.bit_depth) - 1;
-                assert!(self.profile.linear.len() >= cap);
-            } else {
-                assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            }
-
             let lut_lin = &self.profile.linear;
+            assert_lut_min_len!(T, lut_lin.len());
 
             for (src, dst) in src
                 .chunks_exact(src_channels)
                 .zip(dst.chunks_exact_mut(dst_channels))
             {
-                let rp = lut_lin.get_unchecked(src[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(src[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(src[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
+                let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
+                let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
 
                 let mut r = _xmm_load_epi32(rp);
                 let mut g = _xmm_load_epi32(gp);
@@ -189,20 +182,13 @@ where
 
             let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
 
-            // safety precondition for linearization table
-            if T::FINITE {
-                let cap = (1 << self.bit_depth) - 1;
-                assert!(self.profile.linear.len() >= cap);
-            } else {
-                assert!(self.profile.linear.len() >= T::NOT_FINITE_LINEAR_TABLE_SIZE);
-            }
-
             let lut_lin = &self.profile.linear;
+            assert_lut_min_len!(T, lut_lin.len());
 
             for dst in in_out.chunks_exact_mut(src_channels) {
-                let rp = lut_lin.get_unchecked(dst[src_cn.r_i()]._as_usize());
-                let gp = lut_lin.get_unchecked(dst[src_cn.g_i()]._as_usize());
-                let bp = lut_lin.get_unchecked(dst[src_cn.b_i()]._as_usize());
+                let rp = &lut_lin[dst[src_cn.r_i()]._as_usize()];
+                let gp = &lut_lin[dst[src_cn.g_i()]._as_usize()];
+                let bp = &lut_lin[dst[src_cn.b_i()]._as_usize()];
 
                 let mut r = _xmm_load_epi32(rp);
                 let mut g = _xmm_load_epi32(gp);

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1444,18 +1444,18 @@ mod tests {
     #[test]
     fn test_rgb_to_xyz_matrix_equals_colorant_matrix() {
         // Test with SM245B.icc (D65 colorants, no CHAD tag)
-        if let Ok(icc_data) = fs::read("./assets/SM245B.icc") {
-            if let Ok(profile) = ColorProfile::new_from_slice(&icc_data) {
-                let rgb_to_xyz = profile.rgb_to_xyz_matrix();
-                let colorants = profile.colorant_matrix();
+        if let Ok(icc_data) = fs::read("./assets/SM245B.icc")
+            && let Ok(profile) = ColorProfile::new_from_slice(&icc_data)
+        {
+            let rgb_to_xyz = profile.rgb_to_xyz_matrix();
+            let colorants = profile.colorant_matrix();
 
-                for i in 0..3 {
-                    for j in 0..3 {
-                        assert!(
-                            (rgb_to_xyz.v[i][j] - colorants.v[i][j]).abs() < 1e-10,
-                            "rgb_to_xyz_matrix should equal colorant_matrix at [{i}][{j}]"
-                        );
-                    }
+            for i in 0..3 {
+                for j in 0..3 {
+                    assert!(
+                        (rgb_to_xyz.v[i][j] - colorants.v[i][j]).abs() < 1e-10,
+                        "rgb_to_xyz_matrix should equal colorant_matrix at [{i}][{j}]"
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

Replace `get_unchecked` with ordinary `[]` indexing on linearization table lookups in matrix
shaper RGB→XYZ paths (SSE, AVX, NEON).

An `assert_lut_min_len!` macro asserts the table has enough entries for the pixel type's index
range (>=256 for u8, >=65536 for u16/f32/f64). LLVM uses this to elide bounds checks entirely.

9 files changed, -86 lines net. No public API changes.

## Verification

- `cargo-show-asm`: zero `panic_bounds_check` calls in any hot path.
- `cargo test --all-features`: 65/65 pass.