### PR TITLE
Reject CLUT grid dimensions less than 2

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -429,9 +429,9 @@ impl ColorProfile {
                 let mut last_index: usize = 0;
                 for &dim in grid_points.iter().take(in_channels as usize).rev() {
                     let dim_usize = dim as usize;
-                    if dim_usize == 0 {
+                    if dim_usize < 2 {
                         return Err(CmsError::IncorrectlyFormedLut(
-                            "One of grid dimensions is zero".to_string(),
+                            "One of grid dimensions is less than 2".to_string(),
                         ));
                     }
                     let l = match dim_usize
@@ -615,6 +615,9 @@ impl ColorProfile {
             return Err(CmsError::InvalidProfile);
         }
         let grid_points = tag[10];
+        if grid_points < 2 {
+            return Err(CmsError::InvalidProfile);
+        }
         let clut_size = (grid_points as u32).safe_powi(in_chan as u32)? as usize;
 
         if !(1..=parsing_options.max_allowed_clut_size).contains(&clut_size) {
@@ -999,5 +1002,74 @@ impl ColorProfile {
             matrix_coefficients,
             full_range,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::ParsingOptions;
+
+    fn default_options() -> ParsingOptions {
+        ParsingOptions::default()
+    }
+
+    /// Build a minimal mAB tag with a CLUT section.
+    fn make_mab_tag_with_clut(in_chan: u8, out_chan: u8, grid_values: &[u8]) -> Vec<u8> {
+        let clut_offset: u32 = 48;
+        let mut grid_points = [0u8; 16];
+        for (i, &g) in grid_values.iter().enumerate().take(16) {
+            grid_points[i] = g;
+        }
+        let mut clut_size: u32 = 1;
+        for &g in grid_points.iter().take(in_chan as usize) {
+            clut_size = clut_size.saturating_mul(g as u32);
+        }
+        clut_size = clut_size.saturating_mul(out_chan as u32);
+        let total = 48 + 20 + clut_size as usize;
+        let mut tag = vec![0u8; total];
+        let sig = u32::from_ne_bytes(*b"mAB ").to_be().to_be_bytes();
+        tag[0..4].copy_from_slice(&sig);
+        tag[8] = in_chan;
+        tag[9] = out_chan;
+        tag[24..28].copy_from_slice(&clut_offset.to_be_bytes());
+        let co = clut_offset as usize;
+        tag[co..co + 16].copy_from_slice(&grid_points);
+        tag[co + 16] = 1; // entry_size = 1 byte
+        tag
+    }
+
+    /// Build a minimal mft1 (lut8) tag.
+    fn make_mft1_tag(in_chan: u8, out_chan: u8, grid_points: u8) -> Vec<u8> {
+        let clut_size = (grid_points as usize).pow(in_chan as u32) * out_chan as usize;
+        let input_table_size = 256usize * in_chan as usize;
+        let output_table_size = 256usize * out_chan as usize;
+        let total = 48 + input_table_size + clut_size + output_table_size;
+        let mut tag = vec![0u8; total];
+        let sig = u32::from_ne_bytes(*b"mft1").to_be().to_be_bytes();
+        tag[0..4].copy_from_slice(&sig);
+        tag[8] = in_chan;
+        tag[9] = out_chan;
+        tag[10] = grid_points;
+        let one = 0x00010000u32.to_be_bytes();
+        for i in 0..3 {
+            let off = 12 + i * 3 * 4 + i * 4;
+            tag[off..off + 4].copy_from_slice(&one);
+        }
+        tag
+    }
+
+    #[test]
+    fn test_mab_rejects_degenerate_grid_points() {
+        let tag = make_mab_tag_with_clut(3, 3, &[1, 1, 1]);
+        let result = ColorProfile::read_lut_abm_type(&tag, 0, tag.len(), true, &default_options());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mft1_rejects_degenerate_grid_points() {
+        let tag = make_mft1_tag(3, 3, 1);
+        let result = ColorProfile::read_lut_a_to_b_type(&tag, 0, tag.len(), &default_options());
+        assert!(matches!(result, Err(CmsError::InvalidProfile)));
     }
 }


### PR DESCRIPTION
Reject CLUT grid dimensions less than 2. 

- `read_lut_abm_type`: Tighten the existing dimension check from `== 0` to `< 2`
- `read_lut_a_to_b_type`: add a `< 2` check after reading `grid_points`

Note: These validation gaps were discovered during rust icc enablement in Chromium and mitigations are being proposed at FFI level: https://skia-review.googlesource.com/c/skia/+/1215636 

[1] https://skia.googlesource.com/skcms/+/refs/heads/main/skcms.cc#1041