### PR TITLE
Safer SIMD, take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.89.0"
 [dependencies]
 num-traits = "0.2"
 pxfm = "^0.1.1"
+safe_unaligned_simd = "0.2.3"
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.89.0"
 [dependencies]
 num-traits = "0.2"
 pxfm = "^0.1.1"
-safe_unaligned_simd = "0.2.3"
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/src/conversions/avx/interpolator.rs
+++ b/src/conversions/avx/interpolator.rs
@@ -281,7 +281,7 @@ impl<const GRID_SIZE: usize> Fetcher<AvxVectorSse> for TetrahedralAvxSseFetchVec
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,
@@ -462,7 +462,7 @@ impl<const GRID_SIZE: usize, const BINS: usize, U: AsPrimitive<usize>>
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidalAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,
@@ -535,7 +535,7 @@ impl<const GRID_SIZE: usize> PyramidalAvxFma<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,
@@ -596,7 +596,7 @@ impl<const GRID_SIZE: usize> PrismaticAvxFma<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PrismaticAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,
@@ -685,7 +685,7 @@ impl<const GRID_SIZE: usize> PrismaticAvxFmaDouble<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> PyramidAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,
@@ -793,7 +793,7 @@ impl<const GRID_SIZE: usize> PyramidAvxFmaDouble<GRID_SIZE> {
 
 #[cfg(feature = "options")]
 impl<const GRID_SIZE: usize> TetrahedralAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,
@@ -853,7 +853,7 @@ impl<const GRID_SIZE: usize> TetrahedralAvxFmaDouble<GRID_SIZE> {
 }
 
 impl<const GRID_SIZE: usize> TrilinearAvxFmaDouble<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,
@@ -896,7 +896,7 @@ impl<const GRID_SIZE: usize> TrilinearAvxFmaDouble<GRID_SIZE> {
 }
 
 impl<const GRID_SIZE: usize> TrilinearAvxFma<GRID_SIZE> {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     unsafe fn interpolate<U: AsPrimitive<usize>, const BINS: usize>(
         &self,
         in_r: U,

--- a/src/conversions/avx/lut4_to_3.rs
+++ b/src/conversions/avx/lut4_to_3.rs
@@ -76,7 +76,7 @@ where
     u32: AsPrimitive<T>,
     (): LutBarycentricReduction<T, U>,
 {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     fn transform_chunk(
         &self,
         src: &[T],

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -199,9 +199,7 @@ where
                 v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
 
                 let zx = _mm_cvtps_epi32(v);
-                let temporary_first_half: &mut [u16; 8] =
-                    (&mut temporary0.0[..8]).try_into().unwrap();
-                _mm_storeu_si128(temporary_first_half, zx);
+                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
 
                 dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -32,6 +32,8 @@ use crate::conversions::avx::AvxAlignedU16;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbAvx<
@@ -55,7 +57,7 @@ impl<
 where
     u32: AsPrimitive<T>,
 {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     fn transform_impl<const FMA: bool>(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         let src_cn = Layout::from(SRC_LAYOUT);
         let dst_cn = Layout::from(DST_LAYOUT);
@@ -79,8 +81,7 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        unsafe {
-            let m0 = _mm256_setr_ps(
+        let m0 = _mm256_setr_ps(
                 t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
             );
             let m1 = _mm256_setr_ps(
@@ -148,7 +149,7 @@ where
                 v = _mm256_min_ps(v, v_scale);
 
                 let zx = _mm256_cvtps_epi32(v);
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, zx);
+                _mm256_storeu_si256(&mut temporary0.0, zx);
 
                 dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
@@ -198,7 +199,9 @@ where
                 v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
 
                 let zx = _mm_cvtps_epi32(v);
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, zx);
+                let temporary_first_half: &mut [u16; 8] =
+                    (&mut temporary0.0[..8]).try_into().unwrap();
+                _mm_storeu_si128(temporary_first_half, zx);
 
                 dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
@@ -207,7 +210,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/avx/rgb_xyz.rs
+++ b/src/conversions/avx/rgb_xyz.rs
@@ -29,11 +29,10 @@
 #![cfg(feature = "avx_shaper_paths")]
 use crate::conversions::TransformMatrixShaper;
 use crate::conversions::avx::AvxAlignedU16;
+use crate::conversions::simd::x86::{_mm_broadcast_ss, _mm_storeu_si128, _mm256_storeu_si256};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
-use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbAvx<
@@ -82,132 +81,132 @@ where
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
         let m0 = _mm256_setr_ps(
-                t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
+            t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
+        );
+        let m1 = _mm256_setr_ps(
+            t.v[1][0], t.v[1][1], t.v[1][2], 0., t.v[1][0], t.v[1][1], t.v[1][2], 0.,
+        );
+        let m2 = _mm256_setr_ps(
+            t.v[2][0], t.v[2][1], t.v[2][2], 0., t.v[2][0], t.v[2][1], t.v[2][2], 0.,
+        );
+
+        let zeros = _mm_setzero_ps();
+
+        let v_scale = _mm256_set1_ps(scale);
+
+        let mut src = src;
+        let mut dst = dst;
+
+        let src_iter = src.chunks_exact(src_channels * 2);
+        let dst_iter = dst.chunks_exact_mut(dst_channels * 2);
+
+        let (mut r0, mut g0, mut b0, mut a0);
+        let (mut r1, mut g1, mut b1, mut a1);
+
+        for (src, dst) in src_iter.zip(dst_iter) {
+            r0 = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
+            g0 = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
+            b0 = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
+            r1 = _mm_broadcast_ss(
+                &self.profile.r_linear[src[src_cn.r_i() + src_channels]._as_usize()],
             );
-            let m1 = _mm256_setr_ps(
-                t.v[1][0], t.v[1][1], t.v[1][2], 0., t.v[1][0], t.v[1][1], t.v[1][2], 0.,
+            g1 = _mm_broadcast_ss(
+                &self.profile.g_linear[src[src_cn.g_i() + src_channels]._as_usize()],
             );
-            let m2 = _mm256_setr_ps(
-                t.v[2][0], t.v[2][1], t.v[2][2], 0., t.v[2][0], t.v[2][1], t.v[2][2], 0.,
+            b1 = _mm_broadcast_ss(
+                &self.profile.b_linear[src[src_cn.b_i() + src_channels]._as_usize()],
             );
+            a0 = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+            a1 = if src_channels == 4 {
+                src[src_cn.a_i() + src_channels]
+            } else {
+                max_colors
+            };
 
-            let zeros = _mm_setzero_ps();
+            let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
+            let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
+            let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
 
-            let v_scale = _mm256_set1_ps(scale);
+            let mut v = if FMA {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_fmadd_ps(g, m1, v0);
+                _mm256_fmadd_ps(b, m2, v1)
+            } else {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_mul_ps(g, m1);
+                let v2 = _mm256_mul_ps(b, m2);
 
-            let mut src = src;
-            let mut dst = dst;
+                _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
+            };
 
-            let src_iter = src.chunks_exact(src_channels * 2);
-            let dst_iter = dst.chunks_exact_mut(dst_channels * 2);
+            v = _mm256_max_ps(v, _mm256_setzero_ps());
+            v = _mm256_mul_ps(v, v_scale);
+            v = _mm256_min_ps(v, v_scale);
 
-            let (mut r0, mut g0, mut b0, mut a0);
-            let (mut r1, mut g1, mut b1, mut a1);
+            let zx = _mm256_cvtps_epi32(v);
+            _mm256_storeu_si256(&mut temporary0.0, zx);
 
-            for (src, dst) in src_iter.zip(dst_iter) {
-                r0 = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
-                g0 = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
-                b0 = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
-                r1 = _mm_broadcast_ss(
-                    &self.profile.r_linear[src[src_cn.r_i() + src_channels]._as_usize()],
-                );
-                g1 = _mm_broadcast_ss(
-                    &self.profile.g_linear[src[src_cn.g_i() + src_channels]._as_usize()],
-                );
-                b1 = _mm_broadcast_ss(
-                    &self.profile.b_linear[src[src_cn.b_i() + src_channels]._as_usize()],
-                );
-                a0 = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-                a1 = if src_channels == 4 {
-                    src[src_cn.a_i() + src_channels]
-                } else {
-                    max_colors
-                };
-
-                let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
-                let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
-                let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
-
-                let mut v = if FMA {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_fmadd_ps(g, m1, v0);
-                    _mm256_fmadd_ps(b, m2, v1)
-                } else {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_mul_ps(g, m1);
-                    let v2 = _mm256_mul_ps(b, m2);
-
-                    _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
-                };
-
-                v = _mm256_max_ps(v, _mm256_setzero_ps());
-                v = _mm256_mul_ps(v, v_scale);
-                v = _mm256_min_ps(v, v_scale);
-
-                let zx = _mm256_cvtps_epi32(v);
-                _mm256_storeu_si256(&mut temporary0.0, zx);
-
-                dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a0;
-                }
-
-                dst[dst_cn.r_i() + dst_channels] = self.profile.r_gamma[temporary0.0[8] as usize];
-                dst[dst_cn.g_i() + dst_channels] = self.profile.g_gamma[temporary0.0[10] as usize];
-                dst[dst_cn.b_i() + dst_channels] = self.profile.b_gamma[temporary0.0[12] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i() + dst_channels] = a1;
-                }
+            dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a0;
             }
 
-            src = src.chunks_exact(src_channels * 2).remainder();
-            dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
-
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let r = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
-                let g = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
-                let b = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-
-                let mut v = if FMA {
-                    let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
-                    let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
-                    _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1)
-                } else {
-                    let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
-                    let v1 = _mm_mul_ps(g, _mm256_castps256_ps128(m1));
-                    let v2 = _mm_mul_ps(b, _mm256_castps256_ps128(m2));
-
-                    _mm_add_ps(_mm_add_ps(v0, v1), v2)
-                };
-
-                v = _mm_max_ps(v, zeros);
-                v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
-                v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
-
-                let zx = _mm_cvtps_epi32(v);
-                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
-
-                dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+            dst[dst_cn.r_i() + dst_channels] = self.profile.r_gamma[temporary0.0[8] as usize];
+            dst[dst_cn.g_i() + dst_channels] = self.profile.g_gamma[temporary0.0[10] as usize];
+            dst[dst_cn.b_i() + dst_channels] = self.profile.b_gamma[temporary0.0[12] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i() + dst_channels] = a1;
             }
+        }
+
+        src = src.chunks_exact(src_channels * 2).remainder();
+        dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
+
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let r = _mm_broadcast_ss(&self.profile.r_linear[src[src_cn.r_i()]._as_usize()]);
+            let g = _mm_broadcast_ss(&self.profile.g_linear[src[src_cn.g_i()]._as_usize()]);
+            let b = _mm_broadcast_ss(&self.profile.b_linear[src[src_cn.b_i()]._as_usize()]);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+
+            let mut v = if FMA {
+                let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
+                let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
+                _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1)
+            } else {
+                let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
+                let v1 = _mm_mul_ps(g, _mm256_castps256_ps128(m1));
+                let v2 = _mm_mul_ps(b, _mm256_castps256_ps128(m2));
+
+                _mm_add_ps(_mm_add_ps(v0, v1), v2)
+            };
+
+            v = _mm_max_ps(v, zeros);
+            v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
+            v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
+
+            let zx = _mm_cvtps_epi32(v);
+            _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
+
+            dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.b_gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
+            }
+        }
 
         Ok(())
     }

--- a/src/conversions/avx/rgb_xyz_opt.rs
+++ b/src/conversions/avx/rgb_xyz_opt.rs
@@ -192,9 +192,7 @@ where
                 v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
 
                 let zx = _mm_cvtps_epi32(v);
-                let temporary_first_half: &mut [u16; 8] =
-                    (&mut temporary0.0[..8]).try_into().unwrap();
-                _mm_storeu_si128(temporary_first_half, zx);
+                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];

--- a/src/conversions/avx/rgb_xyz_opt.rs
+++ b/src/conversions/avx/rgb_xyz_opt.rs
@@ -32,6 +32,7 @@ use crate::conversions::rgbxyz::TransformMatrixShaperOptimizedV;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
 use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 

--- a/src/conversions/avx/rgb_xyz_opt.rs
+++ b/src/conversions/avx/rgb_xyz_opt.rs
@@ -32,6 +32,7 @@ use crate::conversions::rgbxyz::TransformMatrixShaperOptimizedV;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbOptAvx<
@@ -52,7 +53,7 @@ impl<
 where
     u32: AsPrimitive<T>,
 {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     fn transform_impl<const FMA: bool>(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         let src_cn = Layout::from(SRC_LAYOUT);
         let dst_cn = Layout::from(DST_LAYOUT);
@@ -79,8 +80,7 @@ where
         let lut_lin = &self.profile.linear;
         assert_lut_min_len!(T, lut_lin.len());
 
-        unsafe {
-            let m0 = _mm256_setr_ps(
+        let m0 = _mm256_setr_ps(
                 t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
             );
             let m1 = _mm256_setr_ps(
@@ -142,7 +142,7 @@ where
                 v = _mm256_min_ps(v, v_scale);
 
                 let zx = _mm256_cvtps_epi32(v);
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, zx);
+                _mm256_storeu_si256(&mut temporary0.0, zx);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -192,7 +192,9 @@ where
                 v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
 
                 let zx = _mm_cvtps_epi32(v);
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, zx);
+                let temporary_first_half: &mut [u16; 8] =
+                    (&mut temporary0.0[..8]).try_into().unwrap();
+                _mm_storeu_si128(temporary_first_half, zx);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -201,7 +203,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/avx/rgb_xyz_opt.rs
+++ b/src/conversions/avx/rgb_xyz_opt.rs
@@ -29,11 +29,10 @@
 #![cfg(feature = "avx_shaper_optimized_paths")]
 use crate::conversions::avx::AvxAlignedU16;
 use crate::conversions::rgbxyz::TransformMatrixShaperOptimizedV;
+use crate::conversions::simd::x86::{_mm_broadcast_ss, _mm_storeu_si128, _mm256_storeu_si256};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
-use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbOptAvx<
@@ -82,126 +81,126 @@ where
         assert_lut_min_len!(T, lut_lin.len());
 
         let m0 = _mm256_setr_ps(
-                t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
-            );
-            let m1 = _mm256_setr_ps(
-                t.v[1][0], t.v[1][1], t.v[1][2], 0., t.v[1][0], t.v[1][1], t.v[1][2], 0.,
-            );
-            let m2 = _mm256_setr_ps(
-                t.v[2][0], t.v[2][1], t.v[2][2], 0., t.v[2][0], t.v[2][1], t.v[2][2], 0.,
-            );
+            t.v[0][0], t.v[0][1], t.v[0][2], 0., t.v[0][0], t.v[0][1], t.v[0][2], 0.,
+        );
+        let m1 = _mm256_setr_ps(
+            t.v[1][0], t.v[1][1], t.v[1][2], 0., t.v[1][0], t.v[1][1], t.v[1][2], 0.,
+        );
+        let m2 = _mm256_setr_ps(
+            t.v[2][0], t.v[2][1], t.v[2][2], 0., t.v[2][0], t.v[2][1], t.v[2][2], 0.,
+        );
 
-            let zeros = _mm_setzero_ps();
+        let zeros = _mm_setzero_ps();
 
-            let v_scale = _mm256_set1_ps(scale);
+        let v_scale = _mm256_set1_ps(scale);
 
-            let mut src = src;
-            let mut dst = dst;
+        let mut src = src;
+        let mut dst = dst;
 
-            let src_iter = src.chunks_exact(src_channels * 2);
-            let dst_iter = dst.chunks_exact_mut(dst_channels * 2);
+        let src_iter = src.chunks_exact(src_channels * 2);
+        let dst_iter = dst.chunks_exact_mut(dst_channels * 2);
 
-            let (mut r0, mut g0, mut b0, mut a0);
-            let (mut r1, mut g1, mut b1, mut a1);
+        let (mut r0, mut g0, mut b0, mut a0);
+        let (mut r1, mut g1, mut b1, mut a1);
 
-            for (src, dst) in src_iter.zip(dst_iter) {
-                r0 = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize()]);
-                g0 = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize()]);
-                b0 = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize()]);
-                r1 = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i() + src_channels]._as_usize()]);
-                g1 = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i() + src_channels]._as_usize()]);
-                b1 = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i() + src_channels]._as_usize()]);
-                a0 = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-                a1 = if src_channels == 4 {
-                    src[src_cn.a_i() + src_channels]
-                } else {
-                    max_colors
-                };
+        for (src, dst) in src_iter.zip(dst_iter) {
+            r0 = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+            g0 = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+            b0 = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize()]);
+            r1 = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i() + src_channels]._as_usize()]);
+            g1 = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i() + src_channels]._as_usize()]);
+            b1 = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i() + src_channels]._as_usize()]);
+            a0 = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+            a1 = if src_channels == 4 {
+                src[src_cn.a_i() + src_channels]
+            } else {
+                max_colors
+            };
 
-                let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
-                let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
-                let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
+            let r = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
+            let g = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
+            let b = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
 
-                let mut v = if FMA {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_fmadd_ps(g, m1, v0);
-                    _mm256_fmadd_ps(b, m2, v1)
-                } else {
-                    let v0 = _mm256_mul_ps(r, m0);
-                    let v1 = _mm256_mul_ps(g, m1);
-                    let v2 = _mm256_mul_ps(b, m2);
+            let mut v = if FMA {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_fmadd_ps(g, m1, v0);
+                _mm256_fmadd_ps(b, m2, v1)
+            } else {
+                let v0 = _mm256_mul_ps(r, m0);
+                let v1 = _mm256_mul_ps(g, m1);
+                let v2 = _mm256_mul_ps(b, m2);
 
-                    _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
-                };
+                _mm256_add_ps(_mm256_add_ps(v0, v1), v2)
+            };
 
-                v = _mm256_max_ps(v, _mm256_setzero_ps());
-                v = _mm256_mul_ps(v, v_scale);
-                v = _mm256_min_ps(v, v_scale);
+            v = _mm256_max_ps(v, _mm256_setzero_ps());
+            v = _mm256_mul_ps(v, v_scale);
+            v = _mm256_min_ps(v, v_scale);
 
-                let zx = _mm256_cvtps_epi32(v);
-                _mm256_storeu_si256(&mut temporary0.0, zx);
+            let zx = _mm256_cvtps_epi32(v);
+            _mm256_storeu_si256(&mut temporary0.0, zx);
 
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a0;
-                }
-
-                dst[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
-                dst[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
-                dst[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i() + dst_channels] = a1;
-                }
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a0;
             }
 
-            src = src.chunks_exact(src_channels * 2).remainder();
-            dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
-
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let r = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize()]);
-                let g = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize()]);
-                let b = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize()]);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-
-                let mut v = if FMA {
-                    let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
-                    let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
-                    _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1)
-                } else {
-                    let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
-                    let v1 = _mm_mul_ps(g, _mm256_castps256_ps128(m1));
-                    let v2 = _mm_mul_ps(b, _mm256_castps256_ps128(m2));
-
-                    _mm_add_ps(_mm_add_ps(v0, v1), v2)
-                };
-
-                v = _mm_max_ps(v, zeros);
-                v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
-                v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
-
-                let zx = _mm_cvtps_epi32(v);
-                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
-
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+            dst[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
+            dst[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
+            dst[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i() + dst_channels] = a1;
             }
+        }
+
+        src = src.chunks_exact(src_channels * 2).remainder();
+        dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
+
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let r = _mm_broadcast_ss(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+            let g = _mm_broadcast_ss(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+            let b = _mm_broadcast_ss(&lut_lin[src[src_cn.b_i()]._as_usize()]);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+
+            let mut v = if FMA {
+                let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
+                let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
+                _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1)
+            } else {
+                let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
+                let v1 = _mm_mul_ps(g, _mm256_castps256_ps128(m1));
+                let v2 = _mm_mul_ps(b, _mm256_castps256_ps128(m2));
+
+                _mm_add_ps(_mm_add_ps(v0, v1), v2)
+            };
+
+            v = _mm_max_ps(v, zeros);
+            v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
+            v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
+
+            let zx = _mm_cvtps_epi32(v);
+            _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
+
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
+            }
+        }
 
         Ok(())
     }

--- a/src/conversions/avx/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13_opt.rs
@@ -32,15 +32,18 @@ use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 #[inline]
-#[target_feature(enable = "avx")]
+#[target_feature(enable = "avx2")]
 pub(crate) fn _xmm_broadcast_epi32(f: &i32) -> __m128i {
-    unsafe {
-        let float_ref: &f32 = &*(f as *const i32 as *const f32);
-        _mm_castps_si128(_mm_broadcast_ss(float_ref))
-    }
+    // safe transmute would require `bytemuck` dependency,
+    // but this optimizes into the same code as a transmute:
+    // https://rust.godbolt.org/z/Pfqb7YG7c
+    let float_ref = f32::from_ne_bytes(f.to_ne_bytes());
+    _mm_castps_si128(_mm_broadcast_ss(&float_ref))
 }
 
 pub(crate) struct TransformShaperRgbQ2_13OptAvx<
@@ -89,8 +92,7 @@ where
         let lut_lin = &self.profile.linear;
         assert_lut_min_len!(T, lut_lin.len());
 
-        unsafe {
-            let m0 = _mm256_setr_epi16(
+        let m0 = _mm256_setr_epi16(
                 t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0, t.v[0][0],
                 t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
             );
@@ -159,7 +161,7 @@ where
                 v0 = _mm256_max_epi32(v0, zeros);
                 v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+                _mm256_storeu_si256(&mut temporary0.0, v0);
 
                 r0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i()]._as_usize()]);
                 g0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i()]._as_usize()]);
@@ -213,7 +215,7 @@ where
                 v0 = _mm256_max_epi32(v0, zeros);
                 v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+                _mm256_storeu_si256(&mut temporary0.0, v0);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -261,7 +263,9 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
 
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, v);
+                let temporary_first_half: &mut [u16; 8] =
+                    (&mut temporary0.0[..8]).try_into().unwrap();
+                _mm_storeu_si128(temporary_first_half, v);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -270,7 +274,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }
@@ -298,8 +301,7 @@ where
         let lut_lin = &self.profile.linear;
         assert_lut_min_len!(T, lut_lin.len());
 
-        unsafe {
-            let m0 = _mm256_setr_epi16(
+        let m0 = _mm256_setr_epi16(
                 t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0, t.v[0][0],
                 t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
             );
@@ -355,7 +357,7 @@ where
                 v0 = _mm256_max_epi32(v0, zeros);
                 v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
+                _mm256_storeu_si256(&mut temporary0.0, v0);
 
                 dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -399,7 +401,9 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
 
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, v);
+                let temporary_first_half: &mut [u16; 8] =
+                    (&mut temporary0.0[..8]).try_into().unwrap();
+                _mm_storeu_si128(temporary_first_half, v);
 
                 dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -408,7 +412,6 @@ where
                     dst[src_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/avx/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13_opt.rs
@@ -263,9 +263,7 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
 
-                let temporary_first_half: &mut [u16; 8] =
-                    (&mut temporary0.0[..8]).try_into().unwrap();
-                _mm_storeu_si128(temporary_first_half, v);
+                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -401,9 +399,7 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
 
-                let temporary_first_half: &mut [u16; 8] =
-                    (&mut temporary0.0[..8]).try_into().unwrap();
-                _mm_storeu_si128(temporary_first_half, v);
+                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
 
                 dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];

--- a/src/conversions/avx/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx/rgb_xyz_q2_13_opt.rs
@@ -29,11 +29,10 @@
 #![cfg(feature = "avx_shaper_fixed_point_paths")]
 use crate::conversions::avx::AvxAlignedU16;
 use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
+use crate::conversions::simd::x86::{_mm_broadcast_ss, _mm_storeu_si128, _mm256_storeu_si256};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
-use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 #[inline]
@@ -93,185 +92,185 @@ where
         assert_lut_min_len!(T, lut_lin.len());
 
         let m0 = _mm256_setr_epi16(
-                t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0, t.v[0][0],
-                t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
-            );
-            let m2 = _mm256_setr_epi16(
-                t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0, t.v[2][0], 1, t.v[2][1], 1,
-                t.v[2][2], 1, 0, 0,
-            );
+            t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0, t.v[0][0],
+            t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
+        );
+        let m2 = _mm256_setr_epi16(
+            t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0, t.v[2][0], 1, t.v[2][1], 1, t.v[2][2],
+            1, 0, 0,
+        );
 
-            let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
-            let rnd = _mm256_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
+        let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
+        let rnd = _mm256_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
 
-            let zeros = _mm256_setzero_si256();
+        let zeros = _mm256_setzero_si256();
 
-            let v_max_value = _mm256_set1_epi32(self.gamma_lut as i32 - 1);
+        let v_max_value = _mm256_set1_epi32(self.gamma_lut as i32 - 1);
 
-            let (mut r0, mut g0, mut b0, mut a0);
-            let (mut r1, mut g1, mut b1, mut a1);
+        let (mut r0, mut g0, mut b0, mut a0);
+        let (mut r1, mut g1, mut b1, mut a1);
 
-            let mut src_iter = src.chunks_exact(src_channels * 2);
+        let mut src_iter = src.chunks_exact(src_channels * 2);
 
-            if let Some(src0) = src_iter.next() {
-                r0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.r_i()]._as_usize()]);
-                g0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.g_i()]._as_usize()]);
-                b0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.b_i()]._as_usize()]);
+        if let Some(src0) = src_iter.next() {
+            r0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.r_i()]._as_usize()]);
+            g0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.g_i()]._as_usize()]);
+            b0 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.b_i()]._as_usize()]);
 
-                r1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.r_i() + src_channels]._as_usize()]);
-                g1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.g_i() + src_channels]._as_usize()]);
-                b1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.b_i() + src_channels]._as_usize()]);
+            r1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.r_i() + src_channels]._as_usize()]);
+            g1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.g_i() + src_channels]._as_usize()]);
+            b1 = _xmm_broadcast_epi32(&lut_lin[src0[src_cn.b_i() + src_channels]._as_usize()]);
 
-                a0 = if src_channels == 4 {
-                    src0[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-                a1 = if src_channels == 4 {
-                    src0[src_cn.a_i() + src_channels]
-                } else {
-                    max_colors
-                };
+            a0 = if src_channels == 4 {
+                src0[src_cn.a_i()]
             } else {
-                r0 = _mm_setzero_si128();
-                g0 = _mm_setzero_si128();
-                b0 = _mm_setzero_si128();
-                a0 = max_colors;
-                r1 = _mm_setzero_si128();
-                g1 = _mm_setzero_si128();
-                b1 = _mm_setzero_si128();
-                a1 = max_colors;
+                max_colors
+            };
+            a1 = if src_channels == 4 {
+                src0[src_cn.a_i() + src_channels]
+            } else {
+                max_colors
+            };
+        } else {
+            r0 = _mm_setzero_si128();
+            g0 = _mm_setzero_si128();
+            b0 = _mm_setzero_si128();
+            a0 = max_colors;
+            r1 = _mm_setzero_si128();
+            g1 = _mm_setzero_si128();
+            b1 = _mm_setzero_si128();
+            a1 = max_colors;
+        }
+
+        for (src, dst) in src_iter.zip(dst.chunks_exact_mut(dst_channels * 2)) {
+            let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
+            let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
+            let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
+            zg0 = _mm256_slli_epi32::<16>(zg0);
+
+            let zrg0 = _mm256_or_si256(zr0, zg0);
+            let zbz0 = _mm256_or_si256(zb0, rnd);
+
+            let va0 = _mm256_madd_epi16(zrg0, m0);
+            let va1 = _mm256_madd_epi16(zbz0, m2);
+
+            let mut v0 = _mm256_add_epi32(va0, va1);
+
+            v0 = _mm256_srai_epi32::<PRECISION>(v0);
+            v0 = _mm256_max_epi32(v0, zeros);
+            v0 = _mm256_min_epi32(v0, v_max_value);
+
+            _mm256_storeu_si256(&mut temporary0.0, v0);
+
+            r0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+            g0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+            b0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i()]._as_usize()]);
+
+            r1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i() + src_channels]._as_usize()]);
+            g1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i() + src_channels]._as_usize()]);
+            b1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i() + src_channels]._as_usize()]);
+
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a0;
             }
 
-            for (src, dst) in src_iter.zip(dst.chunks_exact_mut(dst_channels * 2)) {
-                let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
-                let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
-                let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
-                zg0 = _mm256_slli_epi32::<16>(zg0);
-
-                let zrg0 = _mm256_or_si256(zr0, zg0);
-                let zbz0 = _mm256_or_si256(zb0, rnd);
-
-                let va0 = _mm256_madd_epi16(zrg0, m0);
-                let va1 = _mm256_madd_epi16(zbz0, m2);
-
-                let mut v0 = _mm256_add_epi32(va0, va1);
-
-                v0 = _mm256_srai_epi32::<PRECISION>(v0);
-                v0 = _mm256_max_epi32(v0, zeros);
-                v0 = _mm256_min_epi32(v0, v_max_value);
-
-                _mm256_storeu_si256(&mut temporary0.0, v0);
-
-                r0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i()]._as_usize()]);
-                g0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i()]._as_usize()]);
-                b0 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i()]._as_usize()]);
-
-                r1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i() + src_channels]._as_usize()]);
-                g1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i() + src_channels]._as_usize()]);
-                b1 = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i() + src_channels]._as_usize()]);
-
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a0;
-                }
-
-                dst[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
-                dst[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
-                dst[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i() + dst_channels] = a1;
-                }
-
-                a0 = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-                a1 = if src_channels == 4 {
-                    src[src_cn.a_i() + src_channels]
-                } else {
-                    max_colors
-                };
+            dst[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
+            dst[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
+            dst[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i() + dst_channels] = a1;
             }
 
-            if let Some(dst) = dst.chunks_exact_mut(dst_channels * 2).last() {
-                let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
-                let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
-                let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
-                zg0 = _mm256_slli_epi32::<16>(zg0);
+            a0 = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+            a1 = if src_channels == 4 {
+                src[src_cn.a_i() + src_channels]
+            } else {
+                max_colors
+            };
+        }
 
-                let zrg0 = _mm256_or_si256(zr0, zg0);
-                let zbz0 = _mm256_or_si256(zb0, rnd);
+        if let Some(dst) = dst.chunks_exact_mut(dst_channels * 2).last() {
+            let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
+            let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
+            let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
+            zg0 = _mm256_slli_epi32::<16>(zg0);
 
-                let va0 = _mm256_madd_epi16(zrg0, m0);
-                let va1 = _mm256_madd_epi16(zbz0, m2);
+            let zrg0 = _mm256_or_si256(zr0, zg0);
+            let zbz0 = _mm256_or_si256(zb0, rnd);
 
-                let mut v0 = _mm256_add_epi32(va0, va1);
+            let va0 = _mm256_madd_epi16(zrg0, m0);
+            let va1 = _mm256_madd_epi16(zbz0, m2);
 
-                v0 = _mm256_srai_epi32::<PRECISION>(v0);
-                v0 = _mm256_max_epi32(v0, zeros);
-                v0 = _mm256_min_epi32(v0, v_max_value);
+            let mut v0 = _mm256_add_epi32(va0, va1);
 
-                _mm256_storeu_si256(&mut temporary0.0, v0);
+            v0 = _mm256_srai_epi32::<PRECISION>(v0);
+            v0 = _mm256_max_epi32(v0, zeros);
+            v0 = _mm256_min_epi32(v0, v_max_value);
 
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a0;
-                }
+            _mm256_storeu_si256(&mut temporary0.0, v0);
 
-                dst[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
-                dst[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
-                dst[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i() + dst_channels] = a1;
-                }
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a0;
             }
 
-            let src = src.chunks_exact(src_channels * 2).remainder();
-            let dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
-
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let r = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i()]._as_usize()]);
-                let mut g = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i()]._as_usize()]);
-                let b = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i()]._as_usize()]);
-
-                g = _mm_slli_epi32::<16>(g);
-
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-
-                let zrg0 = _mm_or_si128(r, g);
-                let zbz0 = _mm_or_si128(b, _mm256_castsi256_si128(rnd));
-
-                let v0 = _mm_madd_epi16(zrg0, _mm256_castsi256_si128(m0));
-                let v1 = _mm_madd_epi16(zbz0, _mm256_castsi256_si128(m2));
-
-                let mut v = _mm_add_epi32(v0, v1);
-
-                v = _mm_srai_epi32::<PRECISION>(v);
-                v = _mm_max_epi32(v, _mm_setzero_si128());
-                v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
-
-                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
-
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+            dst[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
+            dst[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
+            dst[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i() + dst_channels] = a1;
             }
+        }
+
+        let src = src.chunks_exact(src_channels * 2).remainder();
+        let dst = dst.chunks_exact_mut(dst_channels * 2).into_remainder();
+
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let r = _xmm_broadcast_epi32(&lut_lin[src[src_cn.r_i()]._as_usize()]);
+            let mut g = _xmm_broadcast_epi32(&lut_lin[src[src_cn.g_i()]._as_usize()]);
+            let b = _xmm_broadcast_epi32(&lut_lin[src[src_cn.b_i()]._as_usize()]);
+
+            g = _mm_slli_epi32::<16>(g);
+
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+
+            let zrg0 = _mm_or_si128(r, g);
+            let zbz0 = _mm_or_si128(b, _mm256_castsi256_si128(rnd));
+
+            let v0 = _mm_madd_epi16(zrg0, _mm256_castsi256_si128(m0));
+            let v1 = _mm_madd_epi16(zbz0, _mm256_castsi256_si128(m2));
+
+            let mut v = _mm_add_epi32(v0, v1);
+
+            v = _mm_srai_epi32::<PRECISION>(v);
+            v = _mm_max_epi32(v, _mm_setzero_si128());
+            v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
+
+            _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
+
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
+            }
+        }
 
         Ok(())
     }
@@ -300,114 +299,114 @@ where
         assert_lut_min_len!(T, lut_lin.len());
 
         let m0 = _mm256_setr_epi16(
-                t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0, t.v[0][0],
-                t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
-            );
-            let m2 = _mm256_setr_epi16(
-                t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0, t.v[2][0], 1, t.v[2][1], 1,
-                t.v[2][2], 1, 0, 0,
-            );
+            t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0, t.v[0][0],
+            t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
+        );
+        let m2 = _mm256_setr_epi16(
+            t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0, t.v[2][0], 1, t.v[2][1], 1, t.v[2][2],
+            1, 0, 0,
+        );
 
-            let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
-            let rnd = _mm256_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
+        let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
+        let rnd = _mm256_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
 
-            let zeros = _mm256_setzero_si256();
+        let zeros = _mm256_setzero_si256();
 
-            let v_max_value = _mm256_set1_epi32(self.gamma_lut as i32 - 1);
+        let v_max_value = _mm256_set1_epi32(self.gamma_lut as i32 - 1);
 
-            let (mut r0, mut g0, mut b0, mut a0);
-            let (mut r1, mut g1, mut b1, mut a1);
+        let (mut r0, mut g0, mut b0, mut a0);
+        let (mut r1, mut g1, mut b1, mut a1);
 
-            for dst in in_out.chunks_exact_mut(src_channels * 2) {
-                r0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i()]._as_usize()]);
-                g0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i()]._as_usize()]);
-                b0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i()]._as_usize()]);
+        for dst in in_out.chunks_exact_mut(src_channels * 2) {
+            r0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i()]._as_usize()]);
+            g0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i()]._as_usize()]);
+            b0 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i()]._as_usize()]);
 
-                r1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i() + src_channels]._as_usize()]);
-                g1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i() + src_channels]._as_usize()]);
-                b1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i() + src_channels]._as_usize()]);
+            r1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i() + src_channels]._as_usize()]);
+            g1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i() + src_channels]._as_usize()]);
+            b1 = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i() + src_channels]._as_usize()]);
 
-                a0 = if src_channels == 4 {
-                    dst[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-                a1 = if src_channels == 4 {
-                    dst[src_cn.a_i() + src_channels]
-                } else {
-                    max_colors
-                };
+            a0 = if src_channels == 4 {
+                dst[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+            a1 = if src_channels == 4 {
+                dst[src_cn.a_i() + src_channels]
+            } else {
+                max_colors
+            };
 
-                let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
-                let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
-                let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
-                zg0 = _mm256_slli_epi32::<16>(zg0);
+            let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
+            let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
+            let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
+            zg0 = _mm256_slli_epi32::<16>(zg0);
 
-                let zrg0 = _mm256_or_si256(zr0, zg0);
-                let zbz0 = _mm256_or_si256(zb0, rnd);
+            let zrg0 = _mm256_or_si256(zr0, zg0);
+            let zbz0 = _mm256_or_si256(zb0, rnd);
 
-                let va0 = _mm256_madd_epi16(zrg0, m0);
-                let va1 = _mm256_madd_epi16(zbz0, m2);
+            let va0 = _mm256_madd_epi16(zrg0, m0);
+            let va1 = _mm256_madd_epi16(zbz0, m2);
 
-                let mut v0 = _mm256_add_epi32(va0, va1);
+            let mut v0 = _mm256_add_epi32(va0, va1);
 
-                v0 = _mm256_srai_epi32::<PRECISION>(v0);
-                v0 = _mm256_max_epi32(v0, zeros);
-                v0 = _mm256_min_epi32(v0, v_max_value);
+            v0 = _mm256_srai_epi32::<PRECISION>(v0);
+            v0 = _mm256_max_epi32(v0, zeros);
+            v0 = _mm256_min_epi32(v0, v_max_value);
 
-                _mm256_storeu_si256(&mut temporary0.0, v0);
+            _mm256_storeu_si256(&mut temporary0.0, v0);
 
-                dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[src_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                if src_channels == 4 {
-                    dst[src_cn.a_i()] = a0;
-                }
-
-                dst[src_cn.r_i() + src_channels] = self.profile.gamma[temporary0.0[8] as usize];
-                dst[src_cn.g_i() + src_channels] = self.profile.gamma[temporary0.0[10] as usize];
-                dst[src_cn.b_i() + src_channels] = self.profile.gamma[temporary0.0[12] as usize];
-                if src_channels == 4 {
-                    dst[src_cn.a_i() + src_channels] = a1;
-                }
+            dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[src_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if src_channels == 4 {
+                dst[src_cn.a_i()] = a0;
             }
 
-            let dst = in_out.chunks_exact_mut(src_channels * 2).into_remainder();
-
-            for dst in dst.chunks_exact_mut(src_channels) {
-                let r = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i()]._as_usize()]);
-                let mut g = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i()]._as_usize()]);
-                let b = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i()]._as_usize()]);
-
-                g = _mm_slli_epi32::<16>(g);
-
-                let a = if src_channels == 4 {
-                    dst[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
-
-                let zrg0 = _mm_or_si128(r, g);
-                let zbz0 = _mm_or_si128(b, _mm256_castsi256_si128(rnd));
-
-                let v0 = _mm_madd_epi16(zrg0, _mm256_castsi256_si128(m0));
-                let v1 = _mm_madd_epi16(zbz0, _mm256_castsi256_si128(m2));
-
-                let mut v = _mm_add_epi32(v0, v1);
-
-                v = _mm_srai_epi32::<PRECISION>(v);
-                v = _mm_max_epi32(v, _mm_setzero_si128());
-                v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
-
-                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
-
-                dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[src_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                if src_channels == 4 {
-                    dst[src_cn.a_i()] = a;
-                }
+            dst[src_cn.r_i() + src_channels] = self.profile.gamma[temporary0.0[8] as usize];
+            dst[src_cn.g_i() + src_channels] = self.profile.gamma[temporary0.0[10] as usize];
+            dst[src_cn.b_i() + src_channels] = self.profile.gamma[temporary0.0[12] as usize];
+            if src_channels == 4 {
+                dst[src_cn.a_i() + src_channels] = a1;
             }
+        }
+
+        let dst = in_out.chunks_exact_mut(src_channels * 2).into_remainder();
+
+        for dst in dst.chunks_exact_mut(src_channels) {
+            let r = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.r_i()]._as_usize()]);
+            let mut g = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.g_i()]._as_usize()]);
+            let b = _xmm_broadcast_epi32(&lut_lin[dst[src_cn.b_i()]._as_usize()]);
+
+            g = _mm_slli_epi32::<16>(g);
+
+            let a = if src_channels == 4 {
+                dst[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+
+            let zrg0 = _mm_or_si128(r, g);
+            let zbz0 = _mm_or_si128(b, _mm256_castsi256_si128(rnd));
+
+            let v0 = _mm_madd_epi16(zrg0, _mm256_castsi256_si128(m0));
+            let v1 = _mm_madd_epi16(zbz0, _mm256_castsi256_si128(m2));
+
+            let mut v = _mm_add_epi32(v0, v1);
+
+            v = _mm_srai_epi32::<PRECISION>(v);
+            v = _mm_max_epi32(v, _mm_setzero_si128());
+            v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
+
+            _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
+
+            dst[src_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[src_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[src_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if src_channels == 4 {
+                dst[src_cn.a_i()] = a;
+            }
+        }
 
         Ok(())
     }

--- a/src/conversions/avx/t_lut3_to_3.rs
+++ b/src/conversions/avx/t_lut3_to_3.rs
@@ -78,7 +78,7 @@ where
     u32: AsPrimitive<T>,
     (): LutBarycentricReduction<T, U>,
 {
-    #[target_feature(enable = "avx2", enable = "fma")]
+    #[target_feature(enable = "avx2,fma")]
     fn transform_chunk(
         &self,
         src: &[T],

--- a/src/conversions/avx512/rgb_xyz_opt.rs
+++ b/src/conversions/avx512/rgb_xyz_opt.rs
@@ -34,6 +34,8 @@ use crate::conversions::avx512::rgb_xyz_q2_13_opt::{
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbOptAvx512<
@@ -56,7 +58,7 @@ impl<
 where
     u32: AsPrimitive<T>,
 {
-    #[target_feature(enable = "avx512bw", enable = "avx512vl", enable = "fma")]
+    #[target_feature(enable = "avx512bw,avx512vl,fma")]
     fn transform_impl(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         let src_cn = Layout::from(SRC_LAYOUT);
         let dst_cn = Layout::from(DST_LAYOUT);
@@ -84,8 +86,7 @@ where
         let mut temporary0 = AvxAlignedU16([0; 16]);
         let mut temporary1 = AvxAlignedU16([0; 16]);
 
-        unsafe {
-            let m0 = _mm256_setr_ps(
+        let m0 = _mm256_setr_ps(
                 t.v[0][0], t.v[0][1], t.v[0][2], 0f32, t.v[0][0], t.v[0][1], t.v[0][2], 0f32,
             );
             let m1 = _mm256_setr_ps(
@@ -191,8 +192,8 @@ where
 
                     let zx0 = _mm256_cvtps_epi32(vz0);
                     let zx1 = _mm256_cvtps_epi32(vz1);
-                    _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, zx0);
-                    _mm256_store_si256(temporary1.0.as_mut_ptr() as *mut _, zx1);
+                    _mm256_storeu_si256(&mut temporary0.0, zx0);
+                    _mm256_storeu_si256(&mut temporary1.0, zx1);
 
                     dst0[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                     dst0[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -252,7 +253,7 @@ where
                 v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
 
                 let zx = _mm_cvtps_epi32(v);
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, zx);
+                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -261,7 +262,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/avx512/rgb_xyz_opt.rs
+++ b/src/conversions/avx512/rgb_xyz_opt.rs
@@ -31,11 +31,10 @@ use crate::conversions::TransformMatrixShaperOptimized;
 use crate::conversions::avx512::rgb_xyz_q2_13_opt::{
     AvxAlignedU16, split_by_twos, split_by_twos_mut,
 };
+use crate::conversions::simd::x86::{_mm_broadcast_ss, _mm_storeu_si128, _mm256_storeu_si256};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
-use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbOptAvx512<
@@ -87,181 +86,175 @@ where
         let mut temporary1 = AvxAlignedU16([0; 16]);
 
         let m0 = _mm256_setr_ps(
-                t.v[0][0], t.v[0][1], t.v[0][2], 0f32, t.v[0][0], t.v[0][1], t.v[0][2], 0f32,
-            );
-            let m1 = _mm256_setr_ps(
-                t.v[1][0], t.v[1][1], t.v[1][2], 0f32, t.v[1][0], t.v[1][1], t.v[1][2], 0f32,
-            );
-            let m2 = _mm256_setr_ps(
-                t.v[2][0], t.v[2][1], t.v[2][2], 0f32, t.v[2][0], t.v[2][1], t.v[2][2], 0f32,
-            );
+            t.v[0][0], t.v[0][1], t.v[0][2], 0f32, t.v[0][0], t.v[0][1], t.v[0][2], 0f32,
+        );
+        let m1 = _mm256_setr_ps(
+            t.v[1][0], t.v[1][1], t.v[1][2], 0f32, t.v[1][0], t.v[1][1], t.v[1][2], 0f32,
+        );
+        let m2 = _mm256_setr_ps(
+            t.v[2][0], t.v[2][1], t.v[2][2], 0f32, t.v[2][0], t.v[2][1], t.v[2][2], 0f32,
+        );
 
-            let zeros = _mm_setzero_ps();
+        let zeros = _mm_setzero_ps();
 
-            let v_scale = _mm256_set1_ps(scale);
+        let v_scale = _mm256_set1_ps(scale);
 
-            if !src_chunks.is_empty() {
-                let (src0, src1) = src_chunks.split_at(src_chunks.len() / 2);
-                let (dst0, dst1) = dst_chunks.split_at_mut(dst_chunks.len() / 2);
-                let src_iter0 = src0.chunks_exact(src_channels * 2);
-                let src_iter1 = src1.chunks_exact(src_channels * 2);
+        if !src_chunks.is_empty() {
+            let (src0, src1) = src_chunks.split_at(src_chunks.len() / 2);
+            let (dst0, dst1) = dst_chunks.split_at_mut(dst_chunks.len() / 2);
+            let src_iter0 = src0.chunks_exact(src_channels * 2);
+            let src_iter1 = src1.chunks_exact(src_channels * 2);
 
-                let (mut r0, mut g0, mut b0, mut a0);
-                let (mut r1, mut g1, mut b1, mut a1);
-                let (mut r2, mut g2, mut b2, mut a2);
-                let (mut r3, mut g3, mut b3, mut a3);
+            let (mut r0, mut g0, mut b0, mut a0);
+            let (mut r1, mut g1, mut b1, mut a1);
+            let (mut r2, mut g2, mut b2, mut a2);
+            let (mut r3, mut g3, mut b3, mut a3);
 
-                for (((src0, src1), dst0), dst1) in src_iter0
-                    .zip(src_iter1)
-                    .zip(dst0.chunks_exact_mut(dst_channels * 2))
-                    .zip(dst1.chunks_exact_mut(dst_channels * 2))
-                {
-                    r0 = _mm_broadcast_ss(&self.profile.linear[src0[src_cn.r_i()]._as_usize()]);
-                    g0 = _mm_broadcast_ss(&self.profile.linear[src0[src_cn.g_i()]._as_usize()]);
-                    b0 = _mm_broadcast_ss(&self.profile.linear[src0[src_cn.b_i()]._as_usize()]);
-
-                    r1 = _mm_broadcast_ss(
-                        &self.profile.linear[src0[src_cn.r_i() + src_channels]._as_usize()],
-                    );
-                    g1 = _mm_broadcast_ss(
-                        &self.profile.linear[src0[src_cn.g_i() + src_channels]._as_usize()],
-                    );
-                    b1 = _mm_broadcast_ss(
-                        &self.profile.linear[src0[src_cn.b_i() + src_channels]._as_usize()],
-                    );
-
-                    r2 = _mm_broadcast_ss(&self.profile.linear[src1[src_cn.r_i()]._as_usize()]);
-                    g2 = _mm_broadcast_ss(&self.profile.linear[src1[src_cn.g_i()]._as_usize()]);
-                    b2 = _mm_broadcast_ss(&self.profile.linear[src1[src_cn.b_i()]._as_usize()]);
-
-                    r3 = _mm_broadcast_ss(
-                        &self.profile.linear[src1[src_cn.r_i() + src_channels]._as_usize()],
-                    );
-                    g3 = _mm_broadcast_ss(
-                        &self.profile.linear[src1[src_cn.g_i() + src_channels]._as_usize()],
-                    );
-                    b3 = _mm_broadcast_ss(
-                        &self.profile.linear[src1[src_cn.b_i() + src_channels]._as_usize()],
-                    );
-
-                    a0 = if src_channels == 4 {
-                        src0[src_cn.a_i()]
-                    } else {
-                        max_colors
-                    };
-                    a1 = if src_channels == 4 {
-                        src0[src_cn.a_i() + src_channels]
-                    } else {
-                        max_colors
-                    };
-
-                    a2 = if src_channels == 4 {
-                        src1[src_cn.a_i()]
-                    } else {
-                        max_colors
-                    };
-                    a3 = if src_channels == 4 {
-                        src1[src_cn.a_i() + src_channels]
-                    } else {
-                        max_colors
-                    };
-
-                    let rz0 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
-                    let gz0 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
-                    let bz0 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
-
-                    let rz1 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r2), r3);
-                    let gz1 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g2), g3);
-                    let bz1 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b2), b3);
-
-                    let v0 = _mm256_mul_ps(rz0, m0);
-                    let v1 = _mm256_fmadd_ps(gz0, m1, v0);
-                    let mut vz0 = _mm256_fmadd_ps(bz0, m2, v1);
-
-                    let v2 = _mm256_mul_ps(rz1, m0);
-                    let v3 = _mm256_fmadd_ps(gz1, m1, v2);
-                    let mut vz1 = _mm256_fmadd_ps(bz1, m2, v3);
-
-                    vz0 = _mm256_max_ps(vz0, _mm256_setzero_ps());
-                    vz0 = _mm256_mul_ps(vz0, v_scale);
-                    vz0 = _mm256_min_ps(vz0, v_scale);
-
-                    vz1 = _mm256_max_ps(vz1, _mm256_setzero_ps());
-                    vz1 = _mm256_mul_ps(vz1, v_scale);
-                    vz1 = _mm256_min_ps(vz1, v_scale);
-
-                    let zx0 = _mm256_cvtps_epi32(vz0);
-                    let zx1 = _mm256_cvtps_epi32(vz1);
-                    _mm256_storeu_si256(&mut temporary0.0, zx0);
-                    _mm256_storeu_si256(&mut temporary1.0, zx1);
-
-                    dst0[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                    dst0[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                    dst0[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                    if dst_channels == 4 {
-                        dst0[dst_cn.a_i()] = a0;
-                    }
-
-                    dst0[dst_cn.r_i() + dst_channels] =
-                        self.profile.gamma[temporary0.0[8] as usize];
-                    dst0[dst_cn.g_i() + dst_channels] =
-                        self.profile.gamma[temporary0.0[10] as usize];
-                    dst0[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[temporary0.0[12] as usize];
-                    if dst_channels == 4 {
-                        dst0[dst_cn.a_i() + dst_channels] = a1;
-                    }
-
-                    dst1[dst_cn.r_i()] = self.profile.gamma[temporary1.0[0] as usize];
-                    dst1[dst_cn.g_i()] = self.profile.gamma[temporary1.0[2] as usize];
-                    dst1[dst_cn.b_i()] = self.profile.gamma[temporary1.0[4] as usize];
-                    if dst_channels == 4 {
-                        dst1[dst_cn.a_i()] = a2;
-                    }
-
-                    dst1[dst_cn.r_i() + dst_channels] =
-                        self.profile.gamma[temporary1.0[8] as usize];
-                    dst1[dst_cn.g_i() + dst_channels] =
-                        self.profile.gamma[temporary1.0[10] as usize];
-                    dst1[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[temporary1.0[12] as usize];
-                    if dst_channels == 4 {
-                        dst1[dst_cn.a_i() + dst_channels] = a3;
-                    }
-                }
-            }
-
-            for (src, dst) in src_remainder
-                .chunks_exact(src_channels)
-                .zip(dst_remainder.chunks_exact_mut(dst_channels))
+            for (((src0, src1), dst0), dst1) in src_iter0
+                .zip(src_iter1)
+                .zip(dst0.chunks_exact_mut(dst_channels * 2))
+                .zip(dst1.chunks_exact_mut(dst_channels * 2))
             {
-                let r = _mm_broadcast_ss(&self.profile.linear[src[src_cn.r_i()]._as_usize()]);
-                let g = _mm_broadcast_ss(&self.profile.linear[src[src_cn.g_i()]._as_usize()]);
-                let b = _mm_broadcast_ss(&self.profile.linear[src[src_cn.b_i()]._as_usize()]);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
+                r0 = _mm_broadcast_ss(&self.profile.linear[src0[src_cn.r_i()]._as_usize()]);
+                g0 = _mm_broadcast_ss(&self.profile.linear[src0[src_cn.g_i()]._as_usize()]);
+                b0 = _mm_broadcast_ss(&self.profile.linear[src0[src_cn.b_i()]._as_usize()]);
+
+                r1 = _mm_broadcast_ss(
+                    &self.profile.linear[src0[src_cn.r_i() + src_channels]._as_usize()],
+                );
+                g1 = _mm_broadcast_ss(
+                    &self.profile.linear[src0[src_cn.g_i() + src_channels]._as_usize()],
+                );
+                b1 = _mm_broadcast_ss(
+                    &self.profile.linear[src0[src_cn.b_i() + src_channels]._as_usize()],
+                );
+
+                r2 = _mm_broadcast_ss(&self.profile.linear[src1[src_cn.r_i()]._as_usize()]);
+                g2 = _mm_broadcast_ss(&self.profile.linear[src1[src_cn.g_i()]._as_usize()]);
+                b2 = _mm_broadcast_ss(&self.profile.linear[src1[src_cn.b_i()]._as_usize()]);
+
+                r3 = _mm_broadcast_ss(
+                    &self.profile.linear[src1[src_cn.r_i() + src_channels]._as_usize()],
+                );
+                g3 = _mm_broadcast_ss(
+                    &self.profile.linear[src1[src_cn.g_i() + src_channels]._as_usize()],
+                );
+                b3 = _mm_broadcast_ss(
+                    &self.profile.linear[src1[src_cn.b_i() + src_channels]._as_usize()],
+                );
+
+                a0 = if src_channels == 4 {
+                    src0[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+                a1 = if src_channels == 4 {
+                    src0[src_cn.a_i() + src_channels]
                 } else {
                     max_colors
                 };
 
-                let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
-                let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
-                let mut v = _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1);
+                a2 = if src_channels == 4 {
+                    src1[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+                a3 = if src_channels == 4 {
+                    src1[src_cn.a_i() + src_channels]
+                } else {
+                    max_colors
+                };
 
-                v = _mm_max_ps(v, zeros);
-                v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
-                v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
+                let rz0 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r0), r1);
+                let gz0 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g0), g1);
+                let bz0 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b0), b1);
 
-                let zx = _mm_cvtps_epi32(v);
-                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
+                let rz1 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(r2), r3);
+                let gz1 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(g2), g3);
+                let bz1 = _mm256_insertf128_ps::<1>(_mm256_castps128_ps256(b2), b3);
 
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+                let v0 = _mm256_mul_ps(rz0, m0);
+                let v1 = _mm256_fmadd_ps(gz0, m1, v0);
+                let mut vz0 = _mm256_fmadd_ps(bz0, m2, v1);
+
+                let v2 = _mm256_mul_ps(rz1, m0);
+                let v3 = _mm256_fmadd_ps(gz1, m1, v2);
+                let mut vz1 = _mm256_fmadd_ps(bz1, m2, v3);
+
+                vz0 = _mm256_max_ps(vz0, _mm256_setzero_ps());
+                vz0 = _mm256_mul_ps(vz0, v_scale);
+                vz0 = _mm256_min_ps(vz0, v_scale);
+
+                vz1 = _mm256_max_ps(vz1, _mm256_setzero_ps());
+                vz1 = _mm256_mul_ps(vz1, v_scale);
+                vz1 = _mm256_min_ps(vz1, v_scale);
+
+                let zx0 = _mm256_cvtps_epi32(vz0);
+                let zx1 = _mm256_cvtps_epi32(vz1);
+                _mm256_storeu_si256(&mut temporary0.0, zx0);
+                _mm256_storeu_si256(&mut temporary1.0, zx1);
+
+                dst0[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+                dst0[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+                dst0[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
                 if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
+                    dst0[dst_cn.a_i()] = a0;
+                }
+
+                dst0[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
+                dst0[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
+                dst0[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
+                if dst_channels == 4 {
+                    dst0[dst_cn.a_i() + dst_channels] = a1;
+                }
+
+                dst1[dst_cn.r_i()] = self.profile.gamma[temporary1.0[0] as usize];
+                dst1[dst_cn.g_i()] = self.profile.gamma[temporary1.0[2] as usize];
+                dst1[dst_cn.b_i()] = self.profile.gamma[temporary1.0[4] as usize];
+                if dst_channels == 4 {
+                    dst1[dst_cn.a_i()] = a2;
+                }
+
+                dst1[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary1.0[8] as usize];
+                dst1[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary1.0[10] as usize];
+                dst1[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary1.0[12] as usize];
+                if dst_channels == 4 {
+                    dst1[dst_cn.a_i() + dst_channels] = a3;
                 }
             }
+        }
+
+        for (src, dst) in src_remainder
+            .chunks_exact(src_channels)
+            .zip(dst_remainder.chunks_exact_mut(dst_channels))
+        {
+            let r = _mm_broadcast_ss(&self.profile.linear[src[src_cn.r_i()]._as_usize()]);
+            let g = _mm_broadcast_ss(&self.profile.linear[src[src_cn.g_i()]._as_usize()]);
+            let b = _mm_broadcast_ss(&self.profile.linear[src[src_cn.b_i()]._as_usize()]);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+
+            let v0 = _mm_mul_ps(r, _mm256_castps256_ps128(m0));
+            let v1 = _mm_fmadd_ps(g, _mm256_castps256_ps128(m1), v0);
+            let mut v = _mm_fmadd_ps(b, _mm256_castps256_ps128(m2), v1);
+
+            v = _mm_max_ps(v, zeros);
+            v = _mm_mul_ps(v, _mm256_castps256_ps128(v_scale));
+            v = _mm_min_ps(v, _mm256_castps256_ps128(v_scale));
+
+            let zx = _mm_cvtps_epi32(v);
+            _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), zx);
+
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
+            }
+        }
 
         Ok(())
     }

--- a/src/conversions/avx512/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx512/rgb_xyz_q2_13_opt.rs
@@ -31,6 +31,8 @@ use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFixedPointOpt;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
+use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
+use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbQ2_13OptAvx512<
@@ -45,10 +47,14 @@ pub(crate) struct TransformShaperRgbQ2_13OptAvx512<
     pub(crate) gamma_lut: usize,
 }
 
-#[inline(always)]
-pub(crate) unsafe fn _xmm_broadcast_epi32(f: &i32) -> __m128i {
-    let float_ref: &f32 = unsafe { &*(f as *const i32 as *const f32) };
-    unsafe { _mm_castps_si128(_mm_broadcast_ss(float_ref)) }
+#[inline]
+#[target_feature(enable = "avx2")]
+pub(crate) fn _xmm_broadcast_epi32(f: &i32) -> __m128i {
+    // safe transmute would require `bytemuck` dependency,
+    // but this optimizes into the same code as a transmute:
+    // https://rust.godbolt.org/z/Pfqb7YG7c
+    let float_ref = f32::from_ne_bytes(f.to_ne_bytes());
+    _mm_castps_si128(_mm_broadcast_ss(&float_ref))
 }
 
 #[repr(align(32), C)]
@@ -78,7 +84,7 @@ impl<
 where
     u32: AsPrimitive<T>,
 {
-    #[target_feature(enable = "avx512bw", enable = "avx512vl")]
+    #[target_feature(enable = "avx512bw,avx512vl")]
     fn transform_avx512(&self, src: &[T], dst: &mut [T]) -> Result<(), CmsError> {
         let src_cn = Layout::from(SRC_LAYOUT);
         let dst_cn = Layout::from(DST_LAYOUT);
@@ -108,8 +114,7 @@ where
         let mut temporary0 = AvxAlignedU16([0; 16]);
         let mut temporary1 = AvxAlignedU16([0; 16]);
 
-        unsafe {
-            let m0 = _mm256_set_epi16(
+        let m0 = _mm256_set_epi16(
                 0, 0, t.v[1][2], t.v[0][2], t.v[1][1], t.v[0][1], t.v[1][0], t.v[0][0], 0, 0,
                 t.v[1][2], t.v[0][2], t.v[1][1], t.v[0][1], t.v[1][0], t.v[0][0],
             );
@@ -224,8 +229,8 @@ where
                     v1 = _mm256_max_epi32(v1, zeros);
                     v1 = _mm256_min_epi32(v1, v_max_value);
 
-                    _mm256_store_si256(temporary0.0.as_mut_ptr() as *mut _, v0);
-                    _mm256_store_si256(temporary1.0.as_mut_ptr() as *mut _, v1);
+                    _mm256_storeu_si256(&mut temporary0.0, v0);
+                    _mm256_storeu_si256(&mut temporary1.0, v1);
 
                     dst0[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                     dst0[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -292,7 +297,7 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
 
-                _mm_store_si128(temporary0.0.as_mut_ptr() as *mut _, v);
+                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -301,7 +306,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/avx512/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/avx512/rgb_xyz_q2_13_opt.rs
@@ -28,11 +28,10 @@
  */
 #![cfg(feature = "avx512_shaper_fixed_point_paths")]
 use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFixedPointOpt;
+use crate::conversions::simd::x86::{_mm_broadcast_ss, _mm_storeu_si128, _mm256_storeu_si256};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-use safe_unaligned_simd::x86_64::_mm_broadcast_ss; // can be replaced with std version once MSRV is >1.90
-use safe_unaligned_simd::x86_64::{_mm_storeu_si128, _mm256_storeu_si256};
 use std::arch::x86_64::*;
 
 pub(crate) struct TransformShaperRgbQ2_13OptAvx512<
@@ -115,197 +114,190 @@ where
         let mut temporary1 = AvxAlignedU16([0; 16]);
 
         let m0 = _mm256_set_epi16(
-                0, 0, t.v[1][2], t.v[0][2], t.v[1][1], t.v[0][1], t.v[1][0], t.v[0][0], 0, 0,
-                t.v[1][2], t.v[0][2], t.v[1][1], t.v[0][1], t.v[1][0], t.v[0][0],
-            );
-            let m2 = _mm256_set_epi16(
-                0, 0, 1, t.v[2][2], 1, t.v[2][1], 1, t.v[2][0], 0, 0, 1, t.v[2][2], 1, t.v[2][1],
-                1, t.v[2][0],
-            );
+            0, 0, t.v[1][2], t.v[0][2], t.v[1][1], t.v[0][1], t.v[1][0], t.v[0][0], 0, 0,
+            t.v[1][2], t.v[0][2], t.v[1][1], t.v[0][1], t.v[1][0], t.v[0][0],
+        );
+        let m2 = _mm256_set_epi16(
+            0, 0, 1, t.v[2][2], 1, t.v[2][1], 1, t.v[2][0], 0, 0, 1, t.v[2][2], 1, t.v[2][1], 1,
+            t.v[2][0],
+        );
 
-            let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
-            let rnd = _mm256_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
+        let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
+        let rnd = _mm256_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
 
-            let zeros = _mm256_setzero_si256();
+        let zeros = _mm256_setzero_si256();
 
-            let v_max_value = _mm256_set1_epi32(self.gamma_lut as i32 - 1);
+        let v_max_value = _mm256_set1_epi32(self.gamma_lut as i32 - 1);
 
-            let (mut r0, mut g0, mut b0, mut a0);
-            let (mut r1, mut g1, mut b1, mut a1);
-            let (mut r2, mut g2, mut b2, mut a2);
-            let (mut r3, mut g3, mut b3, mut a3);
+        let (mut r0, mut g0, mut b0, mut a0);
+        let (mut r1, mut g1, mut b1, mut a1);
+        let (mut r2, mut g2, mut b2, mut a2);
+        let (mut r3, mut g3, mut b3, mut a3);
 
-            if !src_chunks.is_empty() {
-                let (src0, src1) = src_chunks.split_at(src_chunks.len() / 2);
-                let (dst0, dst1) = dst_chunks.split_at_mut(dst_chunks.len() / 2);
-                let src_iter0 = src0.chunks_exact(src_channels * 2);
-                let src_iter1 = src1.chunks_exact(src_channels * 2);
+        if !src_chunks.is_empty() {
+            let (src0, src1) = src_chunks.split_at(src_chunks.len() / 2);
+            let (dst0, dst1) = dst_chunks.split_at_mut(dst_chunks.len() / 2);
+            let src_iter0 = src0.chunks_exact(src_channels * 2);
+            let src_iter1 = src1.chunks_exact(src_channels * 2);
 
-                for (((src0, src1), dst0), dst1) in src_iter0
-                    .zip(src_iter1)
-                    .zip(dst0.chunks_exact_mut(dst_channels * 2))
-                    .zip(dst1.chunks_exact_mut(dst_channels * 2))
-                {
-                    r0 = _xmm_broadcast_epi32(&self.profile.linear[src0[src_cn.r_i()]._as_usize()]);
-                    g0 = _xmm_broadcast_epi32(&self.profile.linear[src0[src_cn.g_i()]._as_usize()]);
-                    b0 = _xmm_broadcast_epi32(&self.profile.linear[src0[src_cn.b_i()]._as_usize()]);
-
-                    r1 = _xmm_broadcast_epi32(
-                        &self.profile.linear[src0[src_cn.r_i() + src_channels]._as_usize()],
-                    );
-                    g1 = _xmm_broadcast_epi32(
-                        &self.profile.linear[src0[src_cn.g_i() + src_channels]._as_usize()],
-                    );
-                    b1 = _xmm_broadcast_epi32(
-                        &self.profile.linear[src0[src_cn.b_i() + src_channels]._as_usize()],
-                    );
-
-                    r2 = _xmm_broadcast_epi32(&self.profile.linear[src1[src_cn.r_i()]._as_usize()]);
-                    g2 = _xmm_broadcast_epi32(&self.profile.linear[src1[src_cn.g_i()]._as_usize()]);
-                    b2 = _xmm_broadcast_epi32(&self.profile.linear[src1[src_cn.b_i()]._as_usize()]);
-
-                    r3 = _xmm_broadcast_epi32(
-                        &self.profile.linear[src1[src_cn.r_i() + src_channels]._as_usize()],
-                    );
-                    g3 = _xmm_broadcast_epi32(
-                        &self.profile.linear[src1[src_cn.g_i() + src_channels]._as_usize()],
-                    );
-                    b3 = _xmm_broadcast_epi32(
-                        &self.profile.linear[src1[src_cn.b_i() + src_channels]._as_usize()],
-                    );
-
-                    a0 = if src_channels == 4 {
-                        src0[src_cn.a_i()]
-                    } else {
-                        max_colors
-                    };
-                    a1 = if src_channels == 4 {
-                        src0[src_cn.a_i() + src_channels]
-                    } else {
-                        max_colors
-                    };
-
-                    a2 = if src_channels == 4 {
-                        src1[src_cn.a_i()]
-                    } else {
-                        max_colors
-                    };
-                    a3 = if src_channels == 4 {
-                        src1[src_cn.a_i() + src_channels]
-                    } else {
-                        max_colors
-                    };
-
-                    let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
-                    let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
-                    let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
-                    zg0 = _mm256_slli_epi32::<16>(zg0);
-
-                    let zr1 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r2), r3);
-                    let mut zg1 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g2), g3);
-                    let zb1 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b2), b3);
-                    zg1 = _mm256_slli_epi32::<16>(zg1);
-
-                    let zrg0 = _mm256_or_si256(zr0, zg0);
-                    let zbz0 = _mm256_or_si256(zb0, rnd);
-
-                    let zrg1 = _mm256_or_si256(zr1, zg1);
-                    let zbz1 = _mm256_or_si256(zb1, rnd);
-
-                    let va0 = _mm256_madd_epi16(zrg0, m0);
-                    let va1 = _mm256_madd_epi16(zbz0, m2);
-
-                    let va2 = _mm256_madd_epi16(zrg1, m0);
-                    let va3 = _mm256_madd_epi16(zbz1, m2);
-
-                    let mut v0 = _mm256_add_epi32(va0, va1);
-                    let mut v1 = _mm256_add_epi32(va2, va3);
-
-                    v0 = _mm256_srai_epi32::<PRECISION>(v0);
-                    v0 = _mm256_max_epi32(v0, zeros);
-                    v0 = _mm256_min_epi32(v0, v_max_value);
-
-                    v1 = _mm256_srai_epi32::<PRECISION>(v1);
-                    v1 = _mm256_max_epi32(v1, zeros);
-                    v1 = _mm256_min_epi32(v1, v_max_value);
-
-                    _mm256_storeu_si256(&mut temporary0.0, v0);
-                    _mm256_storeu_si256(&mut temporary1.0, v1);
-
-                    dst0[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                    dst0[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                    dst0[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
-                    if dst_channels == 4 {
-                        dst0[dst_cn.a_i()] = a0;
-                    }
-
-                    dst0[dst_cn.r_i() + dst_channels] =
-                        self.profile.gamma[temporary0.0[8] as usize];
-                    dst0[dst_cn.g_i() + dst_channels] =
-                        self.profile.gamma[temporary0.0[10] as usize];
-                    dst0[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[temporary0.0[12] as usize];
-                    if dst_channels == 4 {
-                        dst0[dst_cn.a_i() + dst_channels] = a1;
-                    }
-
-                    dst1[dst_cn.r_i()] = self.profile.gamma[temporary1.0[0] as usize];
-                    dst1[dst_cn.g_i()] = self.profile.gamma[temporary1.0[2] as usize];
-                    dst1[dst_cn.b_i()] = self.profile.gamma[temporary1.0[4] as usize];
-                    if dst_channels == 4 {
-                        dst1[dst_cn.a_i()] = a2;
-                    }
-
-                    dst1[dst_cn.r_i() + dst_channels] =
-                        self.profile.gamma[temporary1.0[8] as usize];
-                    dst1[dst_cn.g_i() + dst_channels] =
-                        self.profile.gamma[temporary1.0[10] as usize];
-                    dst1[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[temporary1.0[12] as usize];
-                    if dst_channels == 4 {
-                        dst1[dst_cn.a_i() + dst_channels] = a3;
-                    }
-                }
-            }
-
-            for (src, dst) in src_remainder
-                .chunks_exact(src_channels)
-                .zip(dst_remainder.chunks_exact_mut(dst_channels))
+            for (((src0, src1), dst0), dst1) in src_iter0
+                .zip(src_iter1)
+                .zip(dst0.chunks_exact_mut(dst_channels * 2))
+                .zip(dst1.chunks_exact_mut(dst_channels * 2))
             {
-                let r = _xmm_broadcast_epi32(&self.profile.linear[src[src_cn.r_i()]._as_usize()]);
-                let mut g =
-                    _xmm_broadcast_epi32(&self.profile.linear[src[src_cn.g_i()]._as_usize()]);
-                let b = _xmm_broadcast_epi32(&self.profile.linear[src[src_cn.b_i()]._as_usize()]);
+                r0 = _xmm_broadcast_epi32(&self.profile.linear[src0[src_cn.r_i()]._as_usize()]);
+                g0 = _xmm_broadcast_epi32(&self.profile.linear[src0[src_cn.g_i()]._as_usize()]);
+                b0 = _xmm_broadcast_epi32(&self.profile.linear[src0[src_cn.b_i()]._as_usize()]);
 
-                g = _mm_slli_epi32::<16>(g);
+                r1 = _xmm_broadcast_epi32(
+                    &self.profile.linear[src0[src_cn.r_i() + src_channels]._as_usize()],
+                );
+                g1 = _xmm_broadcast_epi32(
+                    &self.profile.linear[src0[src_cn.g_i() + src_channels]._as_usize()],
+                );
+                b1 = _xmm_broadcast_epi32(
+                    &self.profile.linear[src0[src_cn.b_i() + src_channels]._as_usize()],
+                );
 
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
+                r2 = _xmm_broadcast_epi32(&self.profile.linear[src1[src_cn.r_i()]._as_usize()]);
+                g2 = _xmm_broadcast_epi32(&self.profile.linear[src1[src_cn.g_i()]._as_usize()]);
+                b2 = _xmm_broadcast_epi32(&self.profile.linear[src1[src_cn.b_i()]._as_usize()]);
+
+                r3 = _xmm_broadcast_epi32(
+                    &self.profile.linear[src1[src_cn.r_i() + src_channels]._as_usize()],
+                );
+                g3 = _xmm_broadcast_epi32(
+                    &self.profile.linear[src1[src_cn.g_i() + src_channels]._as_usize()],
+                );
+                b3 = _xmm_broadcast_epi32(
+                    &self.profile.linear[src1[src_cn.b_i() + src_channels]._as_usize()],
+                );
+
+                a0 = if src_channels == 4 {
+                    src0[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+                a1 = if src_channels == 4 {
+                    src0[src_cn.a_i() + src_channels]
                 } else {
                     max_colors
                 };
 
-                let zrg0 = _mm_or_si128(r, g);
-                let zbz0 = _mm_or_si128(b, _mm256_castsi256_si128(rnd));
+                a2 = if src_channels == 4 {
+                    src1[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+                a3 = if src_channels == 4 {
+                    src1[src_cn.a_i() + src_channels]
+                } else {
+                    max_colors
+                };
 
-                let v0 = _mm_madd_epi16(zrg0, _mm256_castsi256_si128(m0));
-                let v1 = _mm_madd_epi16(zbz0, _mm256_castsi256_si128(m2));
+                let zr0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r0), r1);
+                let mut zg0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g0), g1);
+                let zb0 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b0), b1);
+                zg0 = _mm256_slli_epi32::<16>(zg0);
 
-                let mut v = _mm_add_epi32(v0, v1);
+                let zr1 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(r2), r3);
+                let mut zg1 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(g2), g3);
+                let zb1 = _mm256_inserti128_si256::<1>(_mm256_castsi128_si256(b2), b3);
+                zg1 = _mm256_slli_epi32::<16>(zg1);
 
-                v = _mm_srai_epi32::<PRECISION>(v);
-                v = _mm_max_epi32(v, _mm_setzero_si128());
-                v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
+                let zrg0 = _mm256_or_si256(zr0, zg0);
+                let zbz0 = _mm256_or_si256(zb0, rnd);
 
-                _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
+                let zrg1 = _mm256_or_si256(zr1, zg1);
+                let zbz1 = _mm256_or_si256(zb1, rnd);
 
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+                let va0 = _mm256_madd_epi16(zrg0, m0);
+                let va1 = _mm256_madd_epi16(zbz0, m2);
+
+                let va2 = _mm256_madd_epi16(zrg1, m0);
+                let va3 = _mm256_madd_epi16(zbz1, m2);
+
+                let mut v0 = _mm256_add_epi32(va0, va1);
+                let mut v1 = _mm256_add_epi32(va2, va3);
+
+                v0 = _mm256_srai_epi32::<PRECISION>(v0);
+                v0 = _mm256_max_epi32(v0, zeros);
+                v0 = _mm256_min_epi32(v0, v_max_value);
+
+                v1 = _mm256_srai_epi32::<PRECISION>(v1);
+                v1 = _mm256_max_epi32(v1, zeros);
+                v1 = _mm256_min_epi32(v1, v_max_value);
+
+                _mm256_storeu_si256(&mut temporary0.0, v0);
+                _mm256_storeu_si256(&mut temporary1.0, v1);
+
+                dst0[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+                dst0[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+                dst0[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
                 if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
+                    dst0[dst_cn.a_i()] = a0;
+                }
+
+                dst0[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary0.0[8] as usize];
+                dst0[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary0.0[10] as usize];
+                dst0[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary0.0[12] as usize];
+                if dst_channels == 4 {
+                    dst0[dst_cn.a_i() + dst_channels] = a1;
+                }
+
+                dst1[dst_cn.r_i()] = self.profile.gamma[temporary1.0[0] as usize];
+                dst1[dst_cn.g_i()] = self.profile.gamma[temporary1.0[2] as usize];
+                dst1[dst_cn.b_i()] = self.profile.gamma[temporary1.0[4] as usize];
+                if dst_channels == 4 {
+                    dst1[dst_cn.a_i()] = a2;
+                }
+
+                dst1[dst_cn.r_i() + dst_channels] = self.profile.gamma[temporary1.0[8] as usize];
+                dst1[dst_cn.g_i() + dst_channels] = self.profile.gamma[temporary1.0[10] as usize];
+                dst1[dst_cn.b_i() + dst_channels] = self.profile.gamma[temporary1.0[12] as usize];
+                if dst_channels == 4 {
+                    dst1[dst_cn.a_i() + dst_channels] = a3;
                 }
             }
+        }
+
+        for (src, dst) in src_remainder
+            .chunks_exact(src_channels)
+            .zip(dst_remainder.chunks_exact_mut(dst_channels))
+        {
+            let r = _xmm_broadcast_epi32(&self.profile.linear[src[src_cn.r_i()]._as_usize()]);
+            let mut g = _xmm_broadcast_epi32(&self.profile.linear[src[src_cn.g_i()]._as_usize()]);
+            let b = _xmm_broadcast_epi32(&self.profile.linear[src[src_cn.b_i()]._as_usize()]);
+
+            g = _mm_slli_epi32::<16>(g);
+
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+
+            let zrg0 = _mm_or_si128(r, g);
+            let zbz0 = _mm_or_si128(b, _mm256_castsi256_si128(rnd));
+
+            let v0 = _mm_madd_epi16(zrg0, _mm256_castsi256_si128(m0));
+            let v1 = _mm_madd_epi16(zbz0, _mm256_castsi256_si128(m2));
+
+            let mut v = _mm_add_epi32(v0, v1);
+
+            v = _mm_srai_epi32::<PRECISION>(v);
+            v = _mm_max_epi32(v, _mm_setzero_si128());
+            v = _mm_min_epi32(v, _mm256_castsi256_si128(v_max_value));
+
+            _mm_storeu_si128(temporary0.0.first_chunk_mut::<8>().unwrap(), v);
+
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary0.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
+            }
+        }
 
         Ok(())
     }

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -75,6 +75,14 @@ mod rgb_xyz_factory;
 mod rgbxyz;
 mod rgbxyz_fixed;
 mod rgbxyz_float;
+#[cfg(any(
+    all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        any(feature = "sse", feature = "avx", feature = "avx512")
+    ),
+    all(target_arch = "aarch64", feature = "neon")
+))]
+mod simd;
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "sse"))]
 mod sse;
 #[cfg(all(target_arch = "aarch64", feature = "sve"))]

--- a/src/conversions/neon/interpolator.rs
+++ b/src/conversions/neon/interpolator.rs
@@ -30,6 +30,7 @@
 #![cfg(feature = "neon_luts")]
 use crate::conversions::interpolator::{BarycentricWeight, load_bary_weights};
 use crate::conversions::neon::NeonAlignedF32;
+use crate::conversions::simd::aarch64::vld1q_f32;
 use crate::math::{FusedMultiplyAdd, FusedMultiplyNegAdd};
 use num_traits::AsPrimitive;
 use std::arch::aarch64::*;
@@ -209,7 +210,7 @@ impl<const GRID_SIZE: usize> Fetcher<NeonVector> for TetrahedralNeonFetchVector<
             + z as u32) as usize;
         let jx = unsafe { self.cube.get_unchecked(offset..) };
         NeonVector {
-            v: unsafe { vld1q_f32(jx.as_ptr() as *const f32) },
+            v: unsafe { vld1q_f32(&jx.get_unchecked(0).0) },
         }
     }
 }
@@ -226,8 +227,8 @@ impl<const GRID_SIZE: usize> Fetcher<NeonVectorDouble>
         let jx0 = unsafe { self.cube0.get_unchecked(offset..) };
         let jx1 = unsafe { self.cube1.get_unchecked(offset..) };
         NeonVectorDouble {
-            v0: unsafe { vld1q_f32(jx0.as_ptr() as *const f32) },
-            v1: unsafe { vld1q_f32(jx1.as_ptr() as *const f32) },
+            v0: unsafe { vld1q_f32(&jx0.get_unchecked(0).0) },
+            v1: unsafe { vld1q_f32(&jx1.get_unchecked(0).0) },
         }
     }
 }

--- a/src/conversions/neon/interpolator_q0_15.rs
+++ b/src/conversions/neon/interpolator_q0_15.rs
@@ -28,6 +28,7 @@
  */
 #![cfg(feature = "neon_luts")]
 use crate::conversions::interpolator::{BarycentricWeight, load_bary_weights};
+use crate::conversions::simd::aarch64::vld1_s16;
 use num_traits::AsPrimitive;
 use std::arch::aarch64::*;
 use std::ops::{Add, Mul, Sub};
@@ -223,7 +224,7 @@ impl<const GRID_SIZE: usize> Fetcher<NeonVectorQ0_15>
             + z as u32) as usize;
         let jx = unsafe { self.cube.get_unchecked(offset..) };
         NeonVectorQ0_15 {
-            v: unsafe { vld1_s16(jx.as_ptr() as *const i16) },
+            v: unsafe { vld1_s16(&jx.get_unchecked(0).0) },
         }
     }
 }
@@ -242,8 +243,8 @@ impl<const GRID_SIZE: usize> Fetcher<NeonVectorQ0_15Double>
         NeonVectorQ0_15Double {
             v: unsafe {
                 vcombine_s16(
-                    vld1_s16(jx0.as_ptr() as *const i16),
-                    vld1_s16(jx1.as_ptr() as *const i16),
+                    vld1_s16(&jx0.get_unchecked(0).0),
+                    vld1_s16(&jx1.get_unchecked(0).0),
                 )
             },
         }

--- a/src/conversions/neon/rgb_xyz.rs
+++ b/src/conversions/neon/rgb_xyz.rs
@@ -29,6 +29,7 @@
 #![cfg(feature = "neon_shaper_paths")]
 use crate::conversions::neon::{NeonAlignedU16, split_by_twos, split_by_twos_mut};
 use crate::conversions::rgbxyz::TransformMatrixShaperV;
+use crate::conversions::simd::aarch64::{vld1q_dup_f32, vld1q_f32, vst1q_u32};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
@@ -88,9 +89,9 @@ where
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
 
         unsafe {
-            let m0 = vld1q_f32([t.v[0][0], t.v[0][1], t.v[0][2], 0.].as_ptr());
-            let m1 = vld1q_f32([t.v[1][0], t.v[1][1], t.v[1][2], 0.].as_ptr());
-            let m2 = vld1q_f32([t.v[2][0], t.v[2][1], t.v[2][2], 0.].as_ptr());
+            let m0 = vld1q_f32(&[t.v[0][0], t.v[0][1], t.v[0][2], 0.]);
+            let m1 = vld1q_f32(&[t.v[1][0], t.v[1][1], t.v[1][2], 0.]);
+            let m2 = vld1q_f32(&[t.v[2][0], t.v[2][1], t.v[2][2], 0.]);
 
             let v_scale = vdupq_n_f32(scale);
 
@@ -197,10 +198,10 @@ where
                     let zx1 = vcvtq_u32_f32(vr1);
                     let zx2 = vcvtq_u32_f32(vr2);
                     let zx3 = vcvtq_u32_f32(vr3);
-                    vst1q_u32(temporary0.0.as_mut_ptr() as *mut _, zx0);
-                    vst1q_u32(temporary1.0.as_mut_ptr() as *mut _, zx1);
-                    vst1q_u32(temporary2.0.as_mut_ptr() as *mut _, zx2);
-                    vst1q_u32(temporary3.0.as_mut_ptr() as *mut _, zx3);
+                    vst1q_u32(&mut temporary0.0, zx0);
+                    vst1q_u32(&mut temporary1.0, zx1);
+                    vst1q_u32(&mut temporary2.0, zx2);
+                    vst1q_u32(&mut temporary3.0, zx3);
 
                     dst0[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
                     dst0[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];
@@ -262,7 +263,7 @@ where
                 v = vminq_f32(v, v_scale);
 
                 let zx = vcvtq_u32_f32(v);
-                vst1q_u32(temporary0.0.as_mut_ptr() as *mut _, zx);
+                vst1q_u32(&mut temporary0.0, zx);
 
                 dst[dst_cn.r_i()] = self.profile.r_gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.g_gamma[temporary0.0[2] as usize];

--- a/src/conversions/neon/rgb_xyz_opt.rs
+++ b/src/conversions/neon/rgb_xyz_opt.rs
@@ -29,6 +29,7 @@
 #![cfg(feature = "neon_shaper_optimized_paths")]
 use crate::conversions::neon::{NeonAlignedU16, split_by_twos, split_by_twos_mut};
 use crate::conversions::rgbxyz::TransformMatrixShaperOptimizedV;
+use crate::conversions::simd::aarch64::{vld1q_dup_f32, vld1q_f32, vst1q_u32};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
@@ -84,9 +85,9 @@ where
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
 
         unsafe {
-            let m0 = vld1q_f32([t.v[0][0], t.v[0][1], t.v[0][2], 0.].as_ptr());
-            let m1 = vld1q_f32([t.v[1][0], t.v[1][1], t.v[1][2], 0.].as_ptr());
-            let m2 = vld1q_f32([t.v[2][0], t.v[2][1], t.v[2][2], 0.].as_ptr());
+            let m0 = vld1q_f32(&[t.v[0][0], t.v[0][1], t.v[0][2], 0.]);
+            let m1 = vld1q_f32(&[t.v[1][0], t.v[1][1], t.v[1][2], 0.]);
+            let m2 = vld1q_f32(&[t.v[2][0], t.v[2][1], t.v[2][2], 0.]);
 
             let v_scale = vdupq_n_f32(scale);
 
@@ -193,10 +194,10 @@ where
                     let zx1 = vcvtq_u32_f32(vr1);
                     let zx2 = vcvtq_u32_f32(vr2);
                     let zx3 = vcvtq_u32_f32(vr3);
-                    vst1q_u32(temporary0.0.as_mut_ptr() as *mut _, zx0);
-                    vst1q_u32(temporary1.0.as_mut_ptr() as *mut _, zx1);
-                    vst1q_u32(temporary2.0.as_mut_ptr() as *mut _, zx2);
-                    vst1q_u32(temporary3.0.as_mut_ptr() as *mut _, zx3);
+                    vst1q_u32(&mut temporary0.0, zx0);
+                    vst1q_u32(&mut temporary1.0, zx1);
+                    vst1q_u32(&mut temporary2.0, zx2);
+                    vst1q_u32(&mut temporary3.0, zx3);
 
                     dst0[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                     dst0[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];
@@ -258,7 +259,7 @@ where
                 v = vminq_f32(v, v_scale);
 
                 let zx = vcvtq_u32_f32(v);
-                vst1q_u32(temporary0.0.as_mut_ptr() as *mut _, zx);
+                vst1q_u32(&mut temporary0.0, zx);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary0.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary0.0[2] as usize];

--- a/src/conversions/neon/rgb_xyz_q1_30_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q1_30_opt.rs
@@ -29,6 +29,7 @@
 #![cfg(feature = "neon_shaper_fixed_point_paths")]
 use crate::conversions::neon::{split_by_twos, split_by_twos_mut};
 use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
+use crate::conversions::simd::aarch64::{vld1q_dup_s32, vld1q_s32};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
@@ -73,177 +74,175 @@ where
 
         assert_lut_min_len!(T, self.profile.linear.len());
 
-        unsafe {
-            let m0 = vld1q_s32([t.v[0][0], t.v[0][1], t.v[0][2], 0].as_ptr());
-            let m1 = vld1q_s32([t.v[1][0], t.v[1][1], t.v[1][2], 0].as_ptr());
-            let m2 = vld1q_s32([t.v[2][0], t.v[2][1], t.v[2][2], 0].as_ptr());
+        let m0 = vld1q_s32(&[t.v[0][0], t.v[0][1], t.v[0][2], 0]);
+        let m1 = vld1q_s32(&[t.v[1][0], t.v[1][1], t.v[1][2], 0]);
+        let m2 = vld1q_s32(&[t.v[2][0], t.v[2][1], t.v[2][2], 0]);
 
-            let lin_lut = &self.profile.linear;
+        let lin_lut = &self.profile.linear;
 
-            let v_max_value = vdup_n_u16((self.gamma_lut - 1) as u16);
+        let v_max_value = vdup_n_u16((self.gamma_lut - 1) as u16);
 
-            if !src_chunks.is_empty() {
-                let (src0, src1) = src_chunks.split_at(src_chunks.len() / 2);
-                let (dst0, dst1) = dst_chunks.split_at_mut(dst_chunks.len() / 2);
-                let src_iter0 = src0.chunks_exact(src_channels * 2);
-                let src_iter1 = src1.chunks_exact(src_channels * 2);
+        if !src_chunks.is_empty() {
+            let (src0, src1) = src_chunks.split_at(src_chunks.len() / 2);
+            let (dst0, dst1) = dst_chunks.split_at_mut(dst_chunks.len() / 2);
+            let src_iter0 = src0.chunks_exact(src_channels * 2);
+            let src_iter1 = src1.chunks_exact(src_channels * 2);
 
-                let (mut r0, mut g0, mut b0, mut a0);
-                let (mut r1, mut g1, mut b1, mut a1);
-                let (mut r2, mut g2, mut b2, mut a2);
-                let (mut r3, mut g3, mut b3, mut a3);
+            let (mut r0, mut g0, mut b0, mut a0);
+            let (mut r1, mut g1, mut b1, mut a1);
+            let (mut r2, mut g2, mut b2, mut a2);
+            let (mut r3, mut g3, mut b3, mut a3);
 
-                for (((src0, src1), dst0), dst1) in src_iter0
-                    .zip(src_iter1)
-                    .zip(dst0.chunks_exact_mut(dst_channels * 2))
-                    .zip(dst1.chunks_exact_mut(dst_channels * 2))
-                {
-                    let r0p = &lin_lut[src0[src_cn.r_i()]._as_usize()];
-                    let g0p = &lin_lut[src0[src_cn.g_i()]._as_usize()];
-                    let b0p = &lin_lut[src0[src_cn.b_i()]._as_usize()];
-
-                    let r1p = &lin_lut[src0[src_cn.r_i() + src_channels]._as_usize()];
-                    let g1p = &lin_lut[src0[src_cn.g_i() + src_channels]._as_usize()];
-                    let b1p = &lin_lut[src0[src_cn.b_i() + src_channels]._as_usize()];
-
-                    let r2p = &lin_lut[src1[src_cn.r_i()]._as_usize()];
-                    let g2p = &lin_lut[src1[src_cn.g_i()]._as_usize()];
-                    let b2p = &lin_lut[src1[src_cn.b_i()]._as_usize()];
-
-                    let r3p = &lin_lut[src1[src_cn.r_i() + src_channels]._as_usize()];
-                    let g3p = &lin_lut[src1[src_cn.g_i() + src_channels]._as_usize()];
-                    let b3p = &lin_lut[src1[src_cn.b_i() + src_channels]._as_usize()];
-
-                    r0 = vld1q_dup_s32(r0p);
-                    g0 = vld1q_dup_s32(g0p);
-                    b0 = vld1q_dup_s32(b0p);
-
-                    r1 = vld1q_dup_s32(r1p);
-                    g1 = vld1q_dup_s32(g1p);
-                    b1 = vld1q_dup_s32(b1p);
-
-                    r2 = vld1q_dup_s32(r2p);
-                    g2 = vld1q_dup_s32(g2p);
-                    b2 = vld1q_dup_s32(b2p);
-
-                    r3 = vld1q_dup_s32(r3p);
-                    g3 = vld1q_dup_s32(g3p);
-                    b3 = vld1q_dup_s32(b3p);
-
-                    a0 = if src_channels == 4 {
-                        src0[src_cn.a_i()]
-                    } else {
-                        max_colors
-                    };
-
-                    a1 = if src_channels == 4 {
-                        src0[src_cn.a_i() + src_channels]
-                    } else {
-                        max_colors
-                    };
-
-                    a2 = if src_channels == 4 {
-                        src1[src_cn.a_i()]
-                    } else {
-                        max_colors
-                    };
-
-                    a3 = if src_channels == 4 {
-                        src1[src_cn.a_i() + src_channels]
-                    } else {
-                        max_colors
-                    };
-
-                    let v0_0 = vqrdmulhq_s32(r0, m0);
-                    let v0_1 = vqrdmulhq_s32(r1, m0);
-                    let v0_2 = vqrdmulhq_s32(r2, m0);
-                    let v0_3 = vqrdmulhq_s32(r3, m0);
-
-                    let v1_0 = vqrdmlahq_s32(v0_0, g0, m1);
-                    let v1_1 = vqrdmlahq_s32(v0_1, g1, m1);
-                    let v1_2 = vqrdmlahq_s32(v0_2, g2, m1);
-                    let v1_3 = vqrdmlahq_s32(v0_3, g3, m1);
-
-                    let vr0 = vqrdmlahq_s32(v1_0, b0, m2);
-                    let vr1 = vqrdmlahq_s32(v1_1, b1, m2);
-                    let vr2 = vqrdmlahq_s32(v1_2, b2, m2);
-                    let vr3 = vqrdmlahq_s32(v1_3, b3, m2);
-
-                    let mut vr0 = vqmovun_s32(vr0);
-                    let mut vr1 = vqmovun_s32(vr1);
-                    let mut vr2 = vqmovun_s32(vr2);
-                    let mut vr3 = vqmovun_s32(vr3);
-
-                    vr0 = vmin_u16(vr0, v_max_value);
-                    vr1 = vmin_u16(vr1, v_max_value);
-                    vr2 = vmin_u16(vr2, v_max_value);
-                    vr3 = vmin_u16(vr3, v_max_value);
-
-                    dst0[dst_cn.r_i()] = self.profile.gamma[vget_lane_u16::<0>(vr0) as usize];
-                    dst0[dst_cn.g_i()] = self.profile.gamma[vget_lane_u16::<1>(vr0) as usize];
-                    dst0[dst_cn.b_i()] = self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
-                    if dst_channels == 4 {
-                        dst0[dst_cn.a_i()] = a0;
-                    }
-
-                    dst0[dst_cn.r_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<0>(vr1) as usize];
-                    dst0[dst_cn.g_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<1>(vr1) as usize];
-                    dst0[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<2>(vr1) as usize];
-                    if dst_channels == 4 {
-                        dst0[dst_cn.a_i() + dst_channels] = a1;
-                    }
-
-                    dst1[dst_cn.r_i()] = self.profile.gamma[vget_lane_u16::<0>(vr2) as usize];
-                    dst1[dst_cn.g_i()] = self.profile.gamma[vget_lane_u16::<1>(vr2) as usize];
-                    dst1[dst_cn.b_i()] = self.profile.gamma[vget_lane_u16::<2>(vr2) as usize];
-                    if dst_channels == 4 {
-                        dst1[dst_cn.a_i()] = a2;
-                    }
-
-                    dst1[dst_cn.r_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<0>(vr3) as usize];
-                    dst1[dst_cn.g_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<1>(vr3) as usize];
-                    dst1[dst_cn.b_i() + dst_channels] =
-                        self.profile.gamma[vget_lane_u16::<2>(vr3) as usize];
-                    if dst_channels == 4 {
-                        dst1[dst_cn.a_i() + dst_channels] = a3;
-                    }
-                }
-            }
-
-            for (src, dst) in src_remainder
-                .chunks_exact(src_channels)
-                .zip(dst_remainder.chunks_exact_mut(dst_channels))
+            for (((src0, src1), dst0), dst1) in src_iter0
+                .zip(src_iter1)
+                .zip(dst0.chunks_exact_mut(dst_channels * 2))
+                .zip(dst1.chunks_exact_mut(dst_channels * 2))
             {
-                let rp = &lin_lut[src[src_cn.r_i()]._as_usize()];
-                let gp = &lin_lut[src[src_cn.g_i()]._as_usize()];
-                let bp = &lin_lut[src[src_cn.b_i()]._as_usize()];
-                let r = vld1q_dup_s32(rp);
-                let g = vld1q_dup_s32(gp);
-                let b = vld1q_dup_s32(bp);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
+                let r0p = &lin_lut[src0[src_cn.r_i()]._as_usize()];
+                let g0p = &lin_lut[src0[src_cn.g_i()]._as_usize()];
+                let b0p = &lin_lut[src0[src_cn.b_i()]._as_usize()];
+
+                let r1p = &lin_lut[src0[src_cn.r_i() + src_channels]._as_usize()];
+                let g1p = &lin_lut[src0[src_cn.g_i() + src_channels]._as_usize()];
+                let b1p = &lin_lut[src0[src_cn.b_i() + src_channels]._as_usize()];
+
+                let r2p = &lin_lut[src1[src_cn.r_i()]._as_usize()];
+                let g2p = &lin_lut[src1[src_cn.g_i()]._as_usize()];
+                let b2p = &lin_lut[src1[src_cn.b_i()]._as_usize()];
+
+                let r3p = &lin_lut[src1[src_cn.r_i() + src_channels]._as_usize()];
+                let g3p = &lin_lut[src1[src_cn.g_i() + src_channels]._as_usize()];
+                let b3p = &lin_lut[src1[src_cn.b_i() + src_channels]._as_usize()];
+
+                r0 = vld1q_dup_s32(r0p);
+                g0 = vld1q_dup_s32(g0p);
+                b0 = vld1q_dup_s32(b0p);
+
+                r1 = vld1q_dup_s32(r1p);
+                g1 = vld1q_dup_s32(g1p);
+                b1 = vld1q_dup_s32(b1p);
+
+                r2 = vld1q_dup_s32(r2p);
+                g2 = vld1q_dup_s32(g2p);
+                b2 = vld1q_dup_s32(b2p);
+
+                r3 = vld1q_dup_s32(r3p);
+                g3 = vld1q_dup_s32(g3p);
+                b3 = vld1q_dup_s32(b3p);
+
+                a0 = if src_channels == 4 {
+                    src0[src_cn.a_i()]
                 } else {
                     max_colors
                 };
 
-                let v0 = vqrdmulhq_s32(r, m0);
-                let v1 = vqrdmlahq_s32(v0, g, m1);
-                let v = vqrdmlahq_s32(v1, b, m2);
+                a1 = if src_channels == 4 {
+                    src0[src_cn.a_i() + src_channels]
+                } else {
+                    max_colors
+                };
 
-                let mut vr0 = vqmovun_s32(v);
+                a2 = if src_channels == 4 {
+                    src1[src_cn.a_i()]
+                } else {
+                    max_colors
+                };
+
+                a3 = if src_channels == 4 {
+                    src1[src_cn.a_i() + src_channels]
+                } else {
+                    max_colors
+                };
+
+                let v0_0 = vqrdmulhq_s32(r0, m0);
+                let v0_1 = vqrdmulhq_s32(r1, m0);
+                let v0_2 = vqrdmulhq_s32(r2, m0);
+                let v0_3 = vqrdmulhq_s32(r3, m0);
+
+                let v1_0 = vqrdmlahq_s32(v0_0, g0, m1);
+                let v1_1 = vqrdmlahq_s32(v0_1, g1, m1);
+                let v1_2 = vqrdmlahq_s32(v0_2, g2, m1);
+                let v1_3 = vqrdmlahq_s32(v0_3, g3, m1);
+
+                let vr0 = vqrdmlahq_s32(v1_0, b0, m2);
+                let vr1 = vqrdmlahq_s32(v1_1, b1, m2);
+                let vr2 = vqrdmlahq_s32(v1_2, b2, m2);
+                let vr3 = vqrdmlahq_s32(v1_3, b3, m2);
+
+                let mut vr0 = vqmovun_s32(vr0);
+                let mut vr1 = vqmovun_s32(vr1);
+                let mut vr2 = vqmovun_s32(vr2);
+                let mut vr3 = vqmovun_s32(vr3);
+
                 vr0 = vmin_u16(vr0, v_max_value);
+                vr1 = vmin_u16(vr1, v_max_value);
+                vr2 = vmin_u16(vr2, v_max_value);
+                vr3 = vmin_u16(vr3, v_max_value);
 
-                dst[dst_cn.r_i()] = self.profile.gamma[vget_lane_u16::<0>(vr0) as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[vget_lane_u16::<1>(vr0) as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
+                dst0[dst_cn.r_i()] = self.profile.gamma[vget_lane_u16::<0>(vr0) as usize];
+                dst0[dst_cn.g_i()] = self.profile.gamma[vget_lane_u16::<1>(vr0) as usize];
+                dst0[dst_cn.b_i()] = self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
                 if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
+                    dst0[dst_cn.a_i()] = a0;
                 }
+
+                dst0[dst_cn.r_i() + dst_channels] =
+                    self.profile.gamma[vget_lane_u16::<0>(vr1) as usize];
+                dst0[dst_cn.g_i() + dst_channels] =
+                    self.profile.gamma[vget_lane_u16::<1>(vr1) as usize];
+                dst0[dst_cn.b_i() + dst_channels] =
+                    self.profile.gamma[vget_lane_u16::<2>(vr1) as usize];
+                if dst_channels == 4 {
+                    dst0[dst_cn.a_i() + dst_channels] = a1;
+                }
+
+                dst1[dst_cn.r_i()] = self.profile.gamma[vget_lane_u16::<0>(vr2) as usize];
+                dst1[dst_cn.g_i()] = self.profile.gamma[vget_lane_u16::<1>(vr2) as usize];
+                dst1[dst_cn.b_i()] = self.profile.gamma[vget_lane_u16::<2>(vr2) as usize];
+                if dst_channels == 4 {
+                    dst1[dst_cn.a_i()] = a2;
+                }
+
+                dst1[dst_cn.r_i() + dst_channels] =
+                    self.profile.gamma[vget_lane_u16::<0>(vr3) as usize];
+                dst1[dst_cn.g_i() + dst_channels] =
+                    self.profile.gamma[vget_lane_u16::<1>(vr3) as usize];
+                dst1[dst_cn.b_i() + dst_channels] =
+                    self.profile.gamma[vget_lane_u16::<2>(vr3) as usize];
+                if dst_channels == 4 {
+                    dst1[dst_cn.a_i() + dst_channels] = a3;
+                }
+            }
+        }
+
+        for (src, dst) in src_remainder
+            .chunks_exact(src_channels)
+            .zip(dst_remainder.chunks_exact_mut(dst_channels))
+        {
+            let rp = &lin_lut[src[src_cn.r_i()]._as_usize()];
+            let gp = &lin_lut[src[src_cn.g_i()]._as_usize()];
+            let bp = &lin_lut[src[src_cn.b_i()]._as_usize()];
+            let r = vld1q_dup_s32(rp);
+            let g = vld1q_dup_s32(gp);
+            let b = vld1q_dup_s32(bp);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
+
+            let v0 = vqrdmulhq_s32(r, m0);
+            let v1 = vqrdmlahq_s32(v0, g, m1);
+            let v = vqrdmlahq_s32(v1, b, m2);
+
+            let mut vr0 = vqmovun_s32(v);
+            vr0 = vmin_u16(vr0, v_max_value);
+
+            dst[dst_cn.r_i()] = self.profile.gamma[vget_lane_u16::<0>(vr0) as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[vget_lane_u16::<1>(vr0) as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[vget_lane_u16::<2>(vr0) as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
             }
         }
 

--- a/src/conversions/neon/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/neon/rgb_xyz_q2_13_opt.rs
@@ -29,6 +29,7 @@
 #![cfg(feature = "neon_shaper_fixed_point_paths")]
 use crate::conversions::neon::{split_by_twos, split_by_twos_mut};
 use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
+use crate::conversions::simd::aarch64::{vld1_dup_s16, vld1_s16};
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
@@ -80,9 +81,9 @@ where
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, dst_channels);
 
         unsafe {
-            let m0 = vld1_s16([t.v[0][0], t.v[0][1], t.v[0][2], 0].as_ptr());
-            let m1 = vld1_s16([t.v[1][0], t.v[1][1], t.v[1][2], 0].as_ptr());
-            let m2 = vld1_s16([t.v[2][0], t.v[2][1], t.v[2][2], 0].as_ptr());
+            let m0 = vld1_s16(&[t.v[0][0], t.v[0][1], t.v[0][2], 0]);
+            let m1 = vld1_s16(&[t.v[1][0], t.v[1][1], t.v[1][2], 0]);
+            let m2 = vld1_s16(&[t.v[2][0], t.v[2][1], t.v[2][2], 0]);
 
             let v_max_value = vdup_n_u16((self.gamma_lut - 1) as u16);
 
@@ -430,9 +431,9 @@ where
         let (dst_chunks, dst_remainder) = split_by_twos_mut(dst, src_channels);
 
         unsafe {
-            let m0 = vld1_s16([t.v[0][0], t.v[0][1], t.v[0][2], 0].as_ptr());
-            let m1 = vld1_s16([t.v[1][0], t.v[1][1], t.v[1][2], 0].as_ptr());
-            let m2 = vld1_s16([t.v[2][0], t.v[2][1], t.v[2][2], 0].as_ptr());
+            let m0 = vld1_s16(&[t.v[0][0], t.v[0][1], t.v[0][2], 0]);
+            let m1 = vld1_s16(&[t.v[1][0], t.v[1][1], t.v[1][2], 0]);
+            let m2 = vld1_s16(&[t.v[2][0], t.v[2][1], t.v[2][2], 0]);
 
             let v_max_value = vdup_n_u16((self.gamma_lut - 1) as u16);
 

--- a/src/conversions/simd.rs
+++ b/src/conversions/simd.rs
@@ -1,0 +1,125 @@
+/*
+ * // Copyright (c) 2026 safe_unaligned_simd Authors. All rights reserved.
+ * //
+ * // Redistribution and use in source and binary forms, with or without modification,
+ * // are permitted provided that the following conditions are met:
+ * //
+ * // 1.  Redistributions of source code must retain the above copyright notice, this
+ * // list of conditions and the following disclaimer.
+ * //
+ * // 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * // this list of conditions and the following disclaimer in the documentation
+ * // and/or other materials provided with the distribution.
+ * //
+ * // 3.  Neither the name of the copyright holder nor the names of its
+ * // contributors may be used to endorse or promote products derived from
+ * // this software without specific prior written permission.
+ * //
+ * // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * // FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * // DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) mod x86 {
+    use core::ptr;
+
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{self as arch, __m128, __m128i, __m256i};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{self as arch, __m128, __m128i, __m256i};
+
+    pub(crate) unsafe trait Is128BitsUnaligned {}
+    pub(crate) unsafe trait Is256BitsUnaligned {}
+
+    unsafe impl Is128BitsUnaligned for [u16; 8] {}
+    unsafe impl Is256BitsUnaligned for [u16; 16] {}
+
+    #[inline]
+    #[target_feature(enable = "sse")]
+    pub(crate) fn _mm_load_ss(mem_addr: &f32) -> __m128 {
+        unsafe { arch::_mm_load_ss(mem_addr) }
+    }
+
+    // This can use the std intrinsic directly once MSRV is >1.90.
+    #[inline]
+    #[target_feature(enable = "avx")]
+    pub(crate) fn _mm_broadcast_ss(mem_addr: &f32) -> __m128 {
+        #[allow(unused_unsafe)]
+        unsafe {
+            arch::_mm_broadcast_ss(mem_addr)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "sse2")]
+    pub(crate) fn _mm_storeu_si128<T: Is128BitsUnaligned>(mem_addr: &mut T, a: __m128i) {
+        unsafe { arch::_mm_storeu_si128(ptr::from_mut(mem_addr).cast(), a) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx")]
+    pub(crate) fn _mm256_storeu_si256<T: Is256BitsUnaligned>(mem_addr: &mut T, a: __m256i) {
+        unsafe { arch::_mm256_storeu_si256(ptr::from_mut(mem_addr).cast(), a) }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) mod aarch64 {
+    use core::ptr;
+
+    use core::arch::aarch64::{self as arch, float32x4_t, int16x4_t, int32x4_t, uint32x4_t};
+
+    pub(crate) unsafe trait Is128BitsUnaligned {}
+
+    unsafe impl Is128BitsUnaligned for [u16; 8] {}
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    pub(crate) fn vld1_s16(mem_addr: &[i16; 4]) -> int16x4_t {
+        unsafe { arch::vld1_s16(mem_addr.as_ptr()) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    pub(crate) fn vld1_dup_s16(mem_addr: &i16) -> int16x4_t {
+        unsafe { arch::vld1_dup_s16(mem_addr) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    pub(crate) fn vld1q_f32(mem_addr: &[f32; 4]) -> float32x4_t {
+        unsafe { arch::vld1q_f32(mem_addr.as_ptr()) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    pub(crate) fn vld1q_dup_f32(mem_addr: &f32) -> float32x4_t {
+        unsafe { arch::vld1q_dup_f32(mem_addr) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    pub(crate) fn vld1q_s32(mem_addr: &[i32; 4]) -> int32x4_t {
+        unsafe { arch::vld1q_s32(mem_addr.as_ptr()) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    pub(crate) fn vld1q_dup_s32(mem_addr: &i32) -> int32x4_t {
+        unsafe { arch::vld1q_dup_s32(mem_addr) }
+    }
+
+    #[inline]
+    #[target_feature(enable = "neon")]
+    pub(crate) fn vst1q_u32<T: Is128BitsUnaligned>(mem_addr: &mut T, a: uint32x4_t) {
+        unsafe { arch::vst1q_u32(ptr::from_mut(mem_addr).cast(), a) }
+    }
+}

--- a/src/conversions/simd.rs
+++ b/src/conversions/simd.rs
@@ -36,7 +36,20 @@ pub(crate) mod x86 {
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{self as arch, __m128, __m128i, __m256i};
 
+    /// Marker for values that can receive an unaligned 128-bit SIMD store.
+    ///
+    /// # Safety
+    ///
+    /// Implementors must be at least 16 bytes in size and valid to overwrite
+    /// through a raw pointer cast to the intrinsic's destination type.
     pub(crate) unsafe trait Is128BitsUnaligned {}
+
+    /// Marker for values that can receive an unaligned 256-bit SIMD store.
+    ///
+    /// # Safety
+    ///
+    /// Implementors must be at least 32 bytes in size and valid to overwrite
+    /// through a raw pointer cast to the intrinsic's destination type.
     pub(crate) unsafe trait Is256BitsUnaligned {}
 
     unsafe impl Is128BitsUnaligned for [u16; 8] {}
@@ -77,6 +90,12 @@ pub(crate) mod aarch64 {
 
     use core::arch::aarch64::{self as arch, float32x4_t, int16x4_t, int32x4_t, uint32x4_t};
 
+    /// Marker for values that can receive an unaligned 128-bit SIMD store.
+    ///
+    /// # Safety
+    ///
+    /// Implementors must be at least 16 bytes in size and valid to overwrite
+    /// through a raw pointer cast to the intrinsic's destination type.
     pub(crate) unsafe trait Is128BitsUnaligned {}
 
     unsafe impl Is128BitsUnaligned for [u16; 8] {}

--- a/src/conversions/simd.rs
+++ b/src/conversions/simd.rs
@@ -27,33 +27,38 @@
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/// Marker for values that can receive an unaligned 128-bit SIMD store.
+///
+/// # Safety
+///
+/// Implementors must be at least 16 bytes in size and valid to overwrite
+/// through a raw pointer cast to the intrinsic's destination type.
+pub(crate) unsafe trait Is128BitsUnaligned {}
+
+unsafe impl Is128BitsUnaligned for [u16; 8] {}
+
+/// Marker for values that can receive an unaligned 256-bit SIMD store.
+///
+/// # Safety
+///
+/// Implementors must be at least 32 bytes in size and valid to overwrite
+/// through a raw pointer cast to the intrinsic's destination type.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) unsafe trait Is256BitsUnaligned {}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+unsafe impl Is256BitsUnaligned for [u16; 16] {}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod x86 {
     use core::ptr;
+
+    use super::{Is128BitsUnaligned, Is256BitsUnaligned};
 
     #[cfg(target_arch = "x86")]
     use core::arch::x86::{self as arch, __m128, __m128i, __m256i};
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{self as arch, __m128, __m128i, __m256i};
-
-    /// Marker for values that can receive an unaligned 128-bit SIMD store.
-    ///
-    /// # Safety
-    ///
-    /// Implementors must be at least 16 bytes in size and valid to overwrite
-    /// through a raw pointer cast to the intrinsic's destination type.
-    pub(crate) unsafe trait Is128BitsUnaligned {}
-
-    /// Marker for values that can receive an unaligned 256-bit SIMD store.
-    ///
-    /// # Safety
-    ///
-    /// Implementors must be at least 32 bytes in size and valid to overwrite
-    /// through a raw pointer cast to the intrinsic's destination type.
-    pub(crate) unsafe trait Is256BitsUnaligned {}
-
-    unsafe impl Is128BitsUnaligned for [u16; 8] {}
-    unsafe impl Is256BitsUnaligned for [u16; 16] {}
 
     #[inline]
     #[target_feature(enable = "sse")]
@@ -88,17 +93,8 @@ pub(crate) mod x86 {
 pub(crate) mod aarch64 {
     use core::ptr;
 
+    use super::Is128BitsUnaligned;
     use core::arch::aarch64::{self as arch, float32x4_t, int16x4_t, int32x4_t, uint32x4_t};
-
-    /// Marker for values that can receive an unaligned 128-bit SIMD store.
-    ///
-    /// # Safety
-    ///
-    /// Implementors must be at least 16 bytes in size and valid to overwrite
-    /// through a raw pointer cast to the intrinsic's destination type.
-    pub(crate) unsafe trait Is128BitsUnaligned {}
-
-    unsafe impl Is128BitsUnaligned for [u16; 8] {}
 
     #[inline]
     #[target_feature(enable = "neon")]

--- a/src/conversions/sse/rgb_xyz.rs
+++ b/src/conversions/sse/rgb_xyz.rs
@@ -33,6 +33,10 @@ use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
 #[cfg(target_arch = "x86")]
+use safe_unaligned_simd::x86::{_mm_load_ss, _mm_storeu_si128};
+#[cfg(target_arch = "x86_64")]
+use safe_unaligned_simd::x86_64::{_mm_load_ss, _mm_storeu_si128};
+#[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -83,8 +87,7 @@ where
         let scale = (self.gamma_lut - 1) as f32;
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
-        unsafe {
-            let m0 = _mm_setr_ps(t.v[0][0], t.v[0][1], t.v[0][2], 0f32);
+        let m0 = _mm_setr_ps(t.v[0][0], t.v[0][1], t.v[0][2], 0f32);
             let m1 = _mm_setr_ps(t.v[1][0], t.v[1][1], t.v[1][2], 0f32);
             let m2 = _mm_setr_ps(t.v[2][0], t.v[2][1], t.v[2][2], 0f32);
 
@@ -123,7 +126,7 @@ where
                 v = _mm_min_ps(v, v_scale);
 
                 let zx = _mm_cvtps_epi32(v);
-                _mm_store_si128(temporary.0.as_mut_ptr() as *mut _, zx);
+                _mm_storeu_si128(&mut temporary.0, zx);
 
                 dst[dst_cn.r_i()] = self.profile.r_gamma[temporary.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.g_gamma[temporary.0[2] as usize];
@@ -132,7 +135,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/sse/rgb_xyz.rs
+++ b/src/conversions/sse/rgb_xyz.rs
@@ -28,14 +28,11 @@
  */
 #![cfg(feature = "sse_shaper_paths")]
 use crate::conversions::TransformMatrixShaper;
+use crate::conversions::simd::x86::{_mm_load_ss, _mm_storeu_si128};
 use crate::conversions::sse::SseAlignedU16;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-#[cfg(target_arch = "x86")]
-use safe_unaligned_simd::x86::{_mm_load_ss, _mm_storeu_si128};
-#[cfg(target_arch = "x86_64")]
-use safe_unaligned_simd::x86_64::{_mm_load_ss, _mm_storeu_si128};
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -88,53 +85,53 @@ where
         let max_colors: T = ((1 << self.bit_depth) - 1).as_();
 
         let m0 = _mm_setr_ps(t.v[0][0], t.v[0][1], t.v[0][2], 0f32);
-            let m1 = _mm_setr_ps(t.v[1][0], t.v[1][1], t.v[1][2], 0f32);
-            let m2 = _mm_setr_ps(t.v[2][0], t.v[2][1], t.v[2][2], 0f32);
+        let m1 = _mm_setr_ps(t.v[1][0], t.v[1][1], t.v[1][2], 0f32);
+        let m2 = _mm_setr_ps(t.v[2][0], t.v[2][1], t.v[2][2], 0f32);
 
-            let zeros = _mm_setzero_ps();
+        let zeros = _mm_setzero_ps();
 
-            let v_scale = _mm_set1_ps(scale);
+        let v_scale = _mm_set1_ps(scale);
 
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let rp = &self.profile.r_linear[src[src_cn.r_i()]._as_usize()];
-                let gp = &self.profile.g_linear[src[src_cn.g_i()]._as_usize()];
-                let bp = &self.profile.b_linear[src[src_cn.b_i()]._as_usize()];
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let rp = &self.profile.r_linear[src[src_cn.r_i()]._as_usize()];
+            let gp = &self.profile.g_linear[src[src_cn.g_i()]._as_usize()];
+            let bp = &self.profile.b_linear[src[src_cn.b_i()]._as_usize()];
 
-                let mut r = _mm_load_ss(rp);
-                let mut g = _mm_load_ss(gp);
-                let mut b = _mm_load_ss(bp);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
+            let mut r = _mm_load_ss(rp);
+            let mut g = _mm_load_ss(gp);
+            let mut b = _mm_load_ss(bp);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
 
-                r = _mm_shuffle_ps::<0>(r, r);
-                g = _mm_shuffle_ps::<0>(g, g);
-                b = _mm_shuffle_ps::<0>(b, b);
+            r = _mm_shuffle_ps::<0>(r, r);
+            g = _mm_shuffle_ps::<0>(g, g);
+            b = _mm_shuffle_ps::<0>(b, b);
 
-                let v0 = _mm_mul_ps(r, m0);
-                let v1 = _mm_mul_ps(g, m1);
-                let v2 = _mm_mul_ps(b, m2);
+            let v0 = _mm_mul_ps(r, m0);
+            let v1 = _mm_mul_ps(g, m1);
+            let v2 = _mm_mul_ps(b, m2);
 
-                let mut v = _mm_add_ps(_mm_add_ps(v0, v1), v2);
-                v = _mm_max_ps(v, zeros);
-                v = _mm_mul_ps(v, v_scale);
-                v = _mm_min_ps(v, v_scale);
+            let mut v = _mm_add_ps(_mm_add_ps(v0, v1), v2);
+            v = _mm_max_ps(v, zeros);
+            v = _mm_mul_ps(v, v_scale);
+            v = _mm_min_ps(v, v_scale);
 
-                let zx = _mm_cvtps_epi32(v);
-                _mm_storeu_si128(&mut temporary.0, zx);
+            let zx = _mm_cvtps_epi32(v);
+            _mm_storeu_si128(&mut temporary.0, zx);
 
-                dst[dst_cn.r_i()] = self.profile.r_gamma[temporary.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.g_gamma[temporary.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.b_gamma[temporary.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+            dst[dst_cn.r_i()] = self.profile.r_gamma[temporary.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.g_gamma[temporary.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.b_gamma[temporary.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
             }
+        }
 
         Ok(())
     }

--- a/src/conversions/sse/rgb_xyz_opt.rs
+++ b/src/conversions/sse/rgb_xyz_opt.rs
@@ -33,6 +33,10 @@ use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
 #[cfg(target_arch = "x86")]
+use safe_unaligned_simd::x86::{_mm_load_ss, _mm_storeu_si128};
+#[cfg(target_arch = "x86_64")]
+use safe_unaligned_simd::x86_64::{_mm_load_ss, _mm_storeu_si128};
+#[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -82,8 +86,7 @@ where
         let lut_lin = &self.profile.linear;
         assert_lut_min_len!(T, lut_lin.len());
 
-        unsafe {
-            let m0 = _mm_setr_ps(t.v[0][0], t.v[0][1], t.v[0][2], 0f32);
+        let m0 = _mm_setr_ps(t.v[0][0], t.v[0][1], t.v[0][2], 0f32);
             let m1 = _mm_setr_ps(t.v[1][0], t.v[1][1], t.v[1][2], 0f32);
             let m2 = _mm_setr_ps(t.v[2][0], t.v[2][1], t.v[2][2], 0f32);
 
@@ -122,7 +125,7 @@ where
                 v = _mm_min_ps(v, v_scale);
 
                 let zx = _mm_cvtps_epi32(v);
-                _mm_store_si128(temporary.0.as_mut_ptr() as *mut _, zx);
+                _mm_storeu_si128(&mut temporary.0, zx);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
@@ -131,7 +134,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/sse/rgb_xyz_opt.rs
+++ b/src/conversions/sse/rgb_xyz_opt.rs
@@ -28,14 +28,11 @@
  */
 #![cfg(feature = "sse_shaper_optimized_paths")]
 use crate::conversions::rgbxyz::TransformMatrixShaperOptimizedV;
+use crate::conversions::simd::x86::{_mm_load_ss, _mm_storeu_si128};
 use crate::conversions::sse::SseAlignedU16;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-#[cfg(target_arch = "x86")]
-use safe_unaligned_simd::x86::{_mm_load_ss, _mm_storeu_si128};
-#[cfg(target_arch = "x86_64")]
-use safe_unaligned_simd::x86_64::{_mm_load_ss, _mm_storeu_si128};
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -87,53 +84,53 @@ where
         assert_lut_min_len!(T, lut_lin.len());
 
         let m0 = _mm_setr_ps(t.v[0][0], t.v[0][1], t.v[0][2], 0f32);
-            let m1 = _mm_setr_ps(t.v[1][0], t.v[1][1], t.v[1][2], 0f32);
-            let m2 = _mm_setr_ps(t.v[2][0], t.v[2][1], t.v[2][2], 0f32);
+        let m1 = _mm_setr_ps(t.v[1][0], t.v[1][1], t.v[1][2], 0f32);
+        let m2 = _mm_setr_ps(t.v[2][0], t.v[2][1], t.v[2][2], 0f32);
 
-            let zeros = _mm_setzero_ps();
+        let zeros = _mm_setzero_ps();
 
-            let v_scale = _mm_set1_ps(scale);
+        let v_scale = _mm_set1_ps(scale);
 
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
-                let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
-                let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
+            let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
+            let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
 
-                let mut r = _mm_load_ss(rp);
-                let mut g = _mm_load_ss(gp);
-                let mut b = _mm_load_ss(bp);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
+            let mut r = _mm_load_ss(rp);
+            let mut g = _mm_load_ss(gp);
+            let mut b = _mm_load_ss(bp);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
 
-                r = _mm_shuffle_ps::<0>(r, r);
-                g = _mm_shuffle_ps::<0>(g, g);
-                b = _mm_shuffle_ps::<0>(b, b);
+            r = _mm_shuffle_ps::<0>(r, r);
+            g = _mm_shuffle_ps::<0>(g, g);
+            b = _mm_shuffle_ps::<0>(b, b);
 
-                let v0 = _mm_mul_ps(r, m0);
-                let v1 = _mm_mul_ps(g, m1);
-                let v2 = _mm_mul_ps(b, m2);
+            let v0 = _mm_mul_ps(r, m0);
+            let v1 = _mm_mul_ps(g, m1);
+            let v2 = _mm_mul_ps(b, m2);
 
-                let mut v = _mm_add_ps(_mm_add_ps(v0, v1), v2);
-                v = _mm_max_ps(v, zeros);
-                v = _mm_mul_ps(v, v_scale);
-                v = _mm_min_ps(v, v_scale);
+            let mut v = _mm_add_ps(_mm_add_ps(v0, v1), v2);
+            v = _mm_max_ps(v, zeros);
+            v = _mm_mul_ps(v, v_scale);
+            v = _mm_min_ps(v, v_scale);
 
-                let zx = _mm_cvtps_epi32(v);
-                _mm_storeu_si128(&mut temporary.0, zx);
+            let zx = _mm_cvtps_epi32(v);
+            _mm_storeu_si128(&mut temporary.0, zx);
 
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
             }
+        }
 
         Ok(())
     }

--- a/src/conversions/sse/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/sse/rgb_xyz_q2_13_opt.rs
@@ -33,15 +33,23 @@ use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
 #[cfg(target_arch = "x86")]
+use safe_unaligned_simd::x86::{_mm_load_ss, _mm_storeu_si128};
+#[cfg(target_arch = "x86_64")]
+use safe_unaligned_simd::x86_64::{_mm_load_ss, _mm_storeu_si128};
+#[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-#[inline(always)]
+#[inline]
 #[allow(dead_code)]
-pub(crate) unsafe fn _xmm_load_epi32(f: &i32) -> __m128i {
-    let float_ref: &f32 = unsafe { &*(f as *const i32 as *const f32) };
-    unsafe { _mm_castps_si128(_mm_load_ss(float_ref)) }
+#[target_feature(enable = "sse,sse2")]
+pub(crate) fn _xmm_load_epi32(f: &i32) -> __m128i {
+    // safe transmute would require `bytemuck` dependency,
+    // but this optimizes into the same code as a transmute:
+    // https://rust.godbolt.org/z/Pfqb7YG7c
+    let float_ref = f32::from_ne_bytes(f.to_ne_bytes());
+    _mm_castps_si128(_mm_load_ss(&float_ref))
 }
 
 pub(crate) struct TransformShaperQ2_13OptSse<
@@ -87,8 +95,7 @@ where
 
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
-        unsafe {
-            let m0 = _mm_setr_epi16(
+        let m0 = _mm_setr_epi16(
                 t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
             );
             let m2 = _mm_setr_epi16(t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0);
@@ -136,7 +143,7 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, v_max_value);
 
-                _mm_store_si128(temporary.0.as_mut_ptr() as *mut _, v);
+                _mm_storeu_si128(&mut temporary.0, v);
 
                 dst[dst_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
                 dst[dst_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
@@ -145,7 +152,6 @@ where
                     dst[dst_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }
@@ -171,8 +177,7 @@ where
 
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
-        unsafe {
-            let m0 = _mm_setr_epi16(
+        let m0 = _mm_setr_epi16(
                 t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
             );
             let m2 = _mm_setr_epi16(t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0);
@@ -217,7 +222,7 @@ where
                 v = _mm_max_epi32(v, _mm_setzero_si128());
                 v = _mm_min_epi32(v, v_max_value);
 
-                _mm_store_si128(temporary.0.as_mut_ptr() as *mut _, v);
+                _mm_storeu_si128(&mut temporary.0, v);
 
                 dst[src_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
                 dst[src_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
@@ -226,7 +231,6 @@ where
                     dst[src_cn.a_i()] = a;
                 }
             }
-        }
 
         Ok(())
     }

--- a/src/conversions/sse/rgb_xyz_q2_13_opt.rs
+++ b/src/conversions/sse/rgb_xyz_q2_13_opt.rs
@@ -28,14 +28,11 @@
  */
 #![cfg(feature = "sse_shaper_fixed_point_paths")]
 use crate::conversions::rgbxyz_fixed::TransformMatrixShaperFpOptVec;
+use crate::conversions::simd::x86::{_mm_load_ss, _mm_storeu_si128};
 use crate::conversions::sse::SseAlignedU16;
 use crate::transform::PointeeSizeExpressible;
 use crate::{CmsError, Layout, TransformExecutor};
 use num_traits::AsPrimitive;
-#[cfg(target_arch = "x86")]
-use safe_unaligned_simd::x86::{_mm_load_ss, _mm_storeu_si128};
-#[cfg(target_arch = "x86_64")]
-use safe_unaligned_simd::x86_64::{_mm_load_ss, _mm_storeu_si128};
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -96,62 +93,62 @@ where
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
         let m0 = _mm_setr_epi16(
-                t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
-            );
-            let m2 = _mm_setr_epi16(t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0);
+            t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
+        );
+        let m2 = _mm_setr_epi16(t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0);
 
-            let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
-            let rnd = _mm_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
+        let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
+        let rnd = _mm_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
 
-            let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
+        let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
 
-            let lut_lin = &self.profile.linear;
-            assert_lut_min_len!(T, lut_lin.len());
+        let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
-            for (src, dst) in src
-                .chunks_exact(src_channels)
-                .zip(dst.chunks_exact_mut(dst_channels))
-            {
-                let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
-                let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
-                let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
+        for (src, dst) in src
+            .chunks_exact(src_channels)
+            .zip(dst.chunks_exact_mut(dst_channels))
+        {
+            let rp = &lut_lin[src[src_cn.r_i()]._as_usize()];
+            let gp = &lut_lin[src[src_cn.g_i()]._as_usize()];
+            let bp = &lut_lin[src[src_cn.b_i()]._as_usize()];
 
-                let mut r = _xmm_load_epi32(rp);
-                let mut g = _xmm_load_epi32(gp);
-                let mut b = _xmm_load_epi32(bp);
-                let a = if src_channels == 4 {
-                    src[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
+            let mut r = _xmm_load_epi32(rp);
+            let mut g = _xmm_load_epi32(gp);
+            let mut b = _xmm_load_epi32(bp);
+            let a = if src_channels == 4 {
+                src[src_cn.a_i()]
+            } else {
+                max_colors
+            };
 
-                r = _mm_shuffle_epi32::<0>(r);
-                g = _mm_shuffle_epi32::<0>(g);
-                b = _mm_shuffle_epi32::<0>(b);
+            r = _mm_shuffle_epi32::<0>(r);
+            g = _mm_shuffle_epi32::<0>(g);
+            b = _mm_shuffle_epi32::<0>(b);
 
-                g = _mm_slli_epi32::<16>(g);
+            g = _mm_slli_epi32::<16>(g);
 
-                let zrg0 = _mm_or_si128(r, g);
-                let zbz0 = _mm_or_si128(b, rnd);
+            let zrg0 = _mm_or_si128(r, g);
+            let zbz0 = _mm_or_si128(b, rnd);
 
-                let v0 = _mm_madd_epi16(zrg0, m0);
-                let v1 = _mm_madd_epi16(zbz0, m2);
+            let v0 = _mm_madd_epi16(zrg0, m0);
+            let v1 = _mm_madd_epi16(zbz0, m2);
 
-                let mut v = _mm_add_epi32(v0, v1);
+            let mut v = _mm_add_epi32(v0, v1);
 
-                v = _mm_srai_epi32::<PRECISION>(v);
-                v = _mm_max_epi32(v, _mm_setzero_si128());
-                v = _mm_min_epi32(v, v_max_value);
+            v = _mm_srai_epi32::<PRECISION>(v);
+            v = _mm_max_epi32(v, _mm_setzero_si128());
+            v = _mm_min_epi32(v, v_max_value);
 
-                _mm_storeu_si128(&mut temporary.0, v);
+            _mm_storeu_si128(&mut temporary.0, v);
 
-                dst[dst_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
-                dst[dst_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
-                dst[dst_cn.b_i()] = self.profile.gamma[temporary.0[4] as usize];
-                if dst_channels == 4 {
-                    dst[dst_cn.a_i()] = a;
-                }
+            dst[dst_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
+            dst[dst_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
+            dst[dst_cn.b_i()] = self.profile.gamma[temporary.0[4] as usize];
+            if dst_channels == 4 {
+                dst[dst_cn.a_i()] = a;
             }
+        }
 
         Ok(())
     }
@@ -178,59 +175,59 @@ where
         let max_colors = ((1 << self.bit_depth) - 1).as_();
 
         let m0 = _mm_setr_epi16(
-                t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
-            );
-            let m2 = _mm_setr_epi16(t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0);
+            t.v[0][0], t.v[1][0], t.v[0][1], t.v[1][1], t.v[0][2], t.v[1][2], 0, 0,
+        );
+        let m2 = _mm_setr_epi16(t.v[2][0], 1, t.v[2][1], 1, t.v[2][2], 1, 0, 0);
 
-            let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
-            let rnd = _mm_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
+        let rnd_val = ((1i32 << (PRECISION - 1)) as i16).to_ne_bytes();
+        let rnd = _mm_set1_epi32(i32::from_ne_bytes([0, 0, rnd_val[0], rnd_val[1]]));
 
-            let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
+        let v_max_value = _mm_set1_epi32(self.gamma_lut as i32 - 1);
 
-            let lut_lin = &self.profile.linear;
-            assert_lut_min_len!(T, lut_lin.len());
+        let lut_lin = &self.profile.linear;
+        assert_lut_min_len!(T, lut_lin.len());
 
-            for dst in in_out.chunks_exact_mut(src_channels) {
-                let rp = &lut_lin[dst[src_cn.r_i()]._as_usize()];
-                let gp = &lut_lin[dst[src_cn.g_i()]._as_usize()];
-                let bp = &lut_lin[dst[src_cn.b_i()]._as_usize()];
+        for dst in in_out.chunks_exact_mut(src_channels) {
+            let rp = &lut_lin[dst[src_cn.r_i()]._as_usize()];
+            let gp = &lut_lin[dst[src_cn.g_i()]._as_usize()];
+            let bp = &lut_lin[dst[src_cn.b_i()]._as_usize()];
 
-                let mut r = _xmm_load_epi32(rp);
-                let mut g = _xmm_load_epi32(gp);
-                let mut b = _xmm_load_epi32(bp);
-                let a = if src_channels == 4 {
-                    dst[src_cn.a_i()]
-                } else {
-                    max_colors
-                };
+            let mut r = _xmm_load_epi32(rp);
+            let mut g = _xmm_load_epi32(gp);
+            let mut b = _xmm_load_epi32(bp);
+            let a = if src_channels == 4 {
+                dst[src_cn.a_i()]
+            } else {
+                max_colors
+            };
 
-                r = _mm_shuffle_epi32::<0>(r);
-                g = _mm_shuffle_epi32::<0>(g);
-                b = _mm_shuffle_epi32::<0>(b);
+            r = _mm_shuffle_epi32::<0>(r);
+            g = _mm_shuffle_epi32::<0>(g);
+            b = _mm_shuffle_epi32::<0>(b);
 
-                g = _mm_slli_epi32::<16>(g);
+            g = _mm_slli_epi32::<16>(g);
 
-                let zrg0 = _mm_or_si128(r, g);
-                let zbz0 = _mm_or_si128(b, rnd);
+            let zrg0 = _mm_or_si128(r, g);
+            let zbz0 = _mm_or_si128(b, rnd);
 
-                let v0 = _mm_madd_epi16(zrg0, m0);
-                let v1 = _mm_madd_epi16(zbz0, m2);
+            let v0 = _mm_madd_epi16(zrg0, m0);
+            let v1 = _mm_madd_epi16(zbz0, m2);
 
-                let mut v = _mm_add_epi32(v0, v1);
+            let mut v = _mm_add_epi32(v0, v1);
 
-                v = _mm_srai_epi32::<PRECISION>(v);
-                v = _mm_max_epi32(v, _mm_setzero_si128());
-                v = _mm_min_epi32(v, v_max_value);
+            v = _mm_srai_epi32::<PRECISION>(v);
+            v = _mm_max_epi32(v, _mm_setzero_si128());
+            v = _mm_min_epi32(v, v_max_value);
 
-                _mm_storeu_si128(&mut temporary.0, v);
+            _mm_storeu_si128(&mut temporary.0, v);
 
-                dst[src_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
-                dst[src_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
-                dst[src_cn.b_i()] = self.profile.gamma[temporary.0[4] as usize];
-                if src_channels == 4 {
-                    dst[src_cn.a_i()] = a;
-                }
+            dst[src_cn.r_i()] = self.profile.gamma[temporary.0[0] as usize];
+            dst[src_cn.g_i()] = self.profile.gamma[temporary.0[2] as usize];
+            dst[src_cn.b_i()] = self.profile.gamma[temporary.0[4] as usize];
+            if src_channels == 4 {
+                dst[src_cn.a_i()] = a;
             }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Follow-up to #119 - same technique, applied much more widely. Since it's the same pattern over and over, I used Claude to apply it given an initial manually written diff.

TODO:

 - Benchmarks on both x86 and ARM
 - Try using `.as_chunks_mut()` instead of `.chunks_exact_mut()` which would propagate size constraints more clearly
 - Run `cargo fmt` once the code is reviewed - I didn't do it yet to avoid polluting the diff with whitespace changes