### PR TITLE
Fix AVX prismatic double interpolation

### DIFF
--- a/src/conversions/avx/interpolator.rs
+++ b/src/conversions/avx/interpolator.rs
@@ -609,7 +609,7 @@ impl<const GRID_SIZE: usize> PrismaticAvxFmaDouble<GRID_SIZE> {
         let (x, y, z, x_n, y_n, z_n, dr, dg, db) = load_bary_weights(lut, in_r, in_g, in_b);
 
         let c0_0 = r0.fetch(x, y, z);
-        let c0_1 = r0.fetch(x, y, z);
+        let c0_1 = r1.fetch(x, y, z);
 
         let w0 = AvxVector::from(db);
         let w1 = AvxVector::from(dr);
@@ -933,5 +933,66 @@ impl<const GRID_SIZE: usize> TrilinearAvxFma<GRID_SIZE> {
         let (c0, c1) = z0.split();
 
         c0.neg_mla(c0, w2).mla(c1, w2)
+    }
+}
+
+#[cfg(all(test, feature = "options"))]
+mod tests {
+    use super::*;
+
+    #[target_feature(enable = "avx2", enable = "fma")]
+    unsafe fn sse_lanes(v: AvxVectorSse) -> [f32; 4] {
+        let mut out = [0f32; 4];
+        unsafe {
+            _mm_storeu_ps(out.as_mut_ptr(), v.v);
+        }
+        out
+    }
+
+    fn make_table(base: f32) -> Vec<SseAlignedF32> {
+        (0..8)
+            .map(|offset| {
+                let value = base + offset as f32 * 10.0;
+                SseAlignedF32([value, value + 1.0, value + 2.0, value + 3.0])
+            })
+            .collect()
+    }
+
+    #[test]
+    fn prismatic_double_high_half_matches_independent_table1_interpolation() {
+        if !std::arch::is_x86_feature_detected!("avx2")
+            || !std::arch::is_x86_feature_detected!("fma")
+        {
+            return;
+        }
+
+        let table0 = make_table(10.0);
+        let table1 = make_table(1000.0);
+        let weights = [
+            BarycentricWeight {
+                x: 0,
+                x_n: 1,
+                w: 0.25,
+            },
+            BarycentricWeight {
+                x: 0,
+                x_n: 1,
+                w: 0.5,
+            },
+            BarycentricWeight {
+                x: 0,
+                x_n: 1,
+                w: 0.75,
+            },
+        ];
+
+        let interpolator = PrismaticAvxFmaDouble::<2> {};
+        let single = PrismaticAvxFma::<2> {};
+        let (_, high) = interpolator.inter3_sse(&table0, &table1, 0usize, 1usize, 2usize, &weights);
+        let expected_high = single.inter3_sse(&table1, 0usize, 1usize, 2usize, &weights);
+
+        let high = unsafe { sse_lanes(high) };
+        let expected_high = unsafe { sse_lanes(expected_high) };
+        assert_eq!(high, expected_high);
     }
 }

--- a/src/conversions/avx/interpolator_q0_15.rs
+++ b/src/conversions/avx/interpolator_q0_15.rs
@@ -599,7 +599,7 @@ impl<const GRID_SIZE: usize> PrismaticAvxQ0_15Double<GRID_SIZE> {
         let (x, y, z, x_n, y_n, z_n, dr, dg, db) = load_bary_weights(lut, in_r, in_g, in_b);
 
         let c0_0 = r0.fetch(x, y, z);
-        let c0_1 = r0.fetch(x, y, z);
+        let c0_1 = r1.fetch(x, y, z);
 
         let w0 = AvxVectorQ0_15::from(db);
         let w1 = AvxVectorQ0_15::from(dr);
@@ -934,5 +934,64 @@ impl<const GRID_SIZE: usize> TrilinearAvxQ0_15<GRID_SIZE> {
         let (c0, c1) = c0.split();
 
         (c0 * dz).mla(c1, w2)
+    }
+}
+
+#[cfg(all(test, feature = "options"))]
+mod tests {
+    use super::*;
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn sse_lanes(v: AvxVectorQ0_15Sse) -> [i16; 8] {
+        let mut out = [0i16; 8];
+        unsafe {
+            _mm_storeu_si128(out.as_mut_ptr() as *mut __m128i, v.v);
+        }
+        out
+    }
+
+    fn make_table(base: i16) -> Vec<AvxAlignedI16> {
+        (0..8)
+            .map(|offset| {
+                let value = base + offset * 10;
+                AvxAlignedI16([value, value + 1, value + 2, value + 3])
+            })
+            .collect()
+    }
+
+    #[test]
+    fn prismatic_double_high_half_matches_independent_table1_interpolation() {
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        let table0 = make_table(10);
+        let table1 = make_table(1000);
+        let weights = [
+            BarycentricWeight {
+                x: 0,
+                x_n: 1,
+                w: 8192,
+            },
+            BarycentricWeight {
+                x: 0,
+                x_n: 1,
+                w: 16384,
+            },
+            BarycentricWeight {
+                x: 0,
+                x_n: 1,
+                w: 24576,
+            },
+        ];
+
+        let interpolator = PrismaticAvxQ0_15Double::<2> {};
+        let single = PrismaticAvxQ0_15::<2> {};
+        let (_, high) = interpolator.inter3_sse(&table0, &table1, 0usize, 1usize, 2usize, &weights);
+        let expected_high = single.inter3_sse(&table1, 0usize, 1usize, 2usize, &weights);
+
+        let high = unsafe { sse_lanes(high) };
+        let expected_high = unsafe { sse_lanes(expected_high) };
+        assert_eq!(high[..4], expected_high[..4]);
     }
 }


### PR DESCRIPTION
This issue came up during review of moxcms via GPT 5.5. I'm not knowledgeable enough about this code to understand if this is a valid issue or not. It looks convincing enough to me but LLMs are great making stuff up. Please take this with a grain of salt.

## AVX 4D Prismatic Double Interpolation Seeded the High Half From the Wrong Table

Affected code:

- `src/conversions/avx/interpolator.rs`: `PrismaticAvxFmaDouble::interpolate`
- `src/conversions/avx/interpolator_q0_15.rs`: `PrismaticAvxQ0_15Double::interpolate`

Both implementations interpolate two adjacent 3D CLUT slices at once. The low SIMD half is built from `table0` through `r0`, and the high SIMD half is supposed to be built from `table1` through `r1`. The initial corner value for the high half was incorrectly loaded with:

```rust
let c0_1 = r0.fetch(x, y, z);
```

That should be:

```rust
let c0_1 = r1.fetch(x, y, z);
```

All later high-half corner fetches used `r1`, so only the base corner `c0` came from the wrong K-slice. This contaminated the high-half result whenever that base corner had a non-zero interpolation coefficient and the two K-slices differed. The low half remained correct.

Regression tests were added:

- `prismatic_double_high_half_matches_independent_table1_interpolation` in `src/conversions/avx/interpolator.rs`
- `prismatic_double_high_half_matches_independent_table1_interpolation` in `src/conversions/avx/interpolator_q0_15.rs`

Each test constructs two deliberately different 2x2x2 tables. It then checks that the high half returned by the double-table prismatic interpolator matches a standalone prismatic interpolation of `table1`. Before the fix, the high half was pulled toward `table0` because `c0_1` was seeded from `r0`.