### PR TITLE
Accept ICC profiles with an all-zero version field

### DIFF
--- a/src/profile.rs
+++ b/src/profile.rs
@@ -89,6 +89,9 @@ impl TryFrom<u32> for ProfileVersion {
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         // First try exact match for known versions
         match value {
+            // Some non-conformant profiles found in the field zero the version
+            // field; treat exactly zero as v2.0 for compatibility.
+            0x00000000 => return Ok(ProfileVersion::V2_0),
             0x02000000 => return Ok(ProfileVersion::V2_0),
             0x02100000 => return Ok(ProfileVersion::V2_1),
             0x02200000 => return Ok(ProfileVersion::V2_2),
@@ -1479,6 +1482,10 @@ mod tests {
     fn test_profile_version_parsing_standard() {
         // Standard versions should work
         assert_eq!(
+            ProfileVersion::try_from(0x00000000).unwrap(),
+            ProfileVersion::V2_0
+        );
+        assert_eq!(
             ProfileVersion::try_from(0x02000000).unwrap(),
             ProfileVersion::V2_0
         );
@@ -1523,10 +1530,11 @@ mod tests {
     fn test_profile_version_parsing_rejected() {
         // Invalid and unsupported versions should be rejected
 
-        // v0.0 - invalid version (no such ICC spec exists)
+        // v0.1 - invalid version (no such ICC spec exists). Only the exact
+        // all-zero field is accepted for compatibility with existing decoders.
         assert!(
-            ProfileVersion::try_from(0x00000000).is_err(),
-            "v0.0 should be rejected"
+            ProfileVersion::try_from(0x00100000).is_err(),
+            "v0.1 should be rejected"
         );
 
         // v5.0 (iccMAX) - reject because it has different white point requirements


### PR DESCRIPTION
In this change we propose treating zeroed version field as `ProfileVersion::V2_0` when parsing the ICC header.

This is intentionally narrow:

- `0x00000000` is accepted and normalized to v2.0.
- Other `v0.x` values such as `0x00100000` remain rejected.
- Unsupported versions such as v5/iccMAX remain rejected.

The choice of v2.0 matches the fallback used when serializing `ProfileVersion::Unknown` and keeps behavior compatible with skcms for these malformed profiles. It does not attempt to make v0 a valid ICC version generally.

Fixes #190 